### PR TITLE
[Issue #19] Add extra information for synopses to CatalogStore

### DIFF
--- a/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
@@ -49,7 +49,8 @@ public interface CatalogContext {
 
   Path getModelInstancePath(String modelName, String modelInstanceName);
 
-  MSynopsis createSynopsis(String synopsisName, String modeInstanceName) throws CatalogException;
+  MSynopsis createSynopsis(String synopsisName, String modeInstanceName, Integer rows, Double ratio)
+      throws CatalogException;
 
   Collection<MSynopsis> getAllSynopses() throws CatalogException;
 

--- a/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
@@ -37,7 +37,7 @@ public interface CatalogContext {
 
   MModelInstance trainModelInstance(
       String modelName, String modelInstanceName, String schemaName, String tableName,
-      List<String> columnNames) throws CatalogException;
+      List<String> columnNames, Long baseTableRows, Long trainedRows) throws CatalogException;
 
   void dropModelInstance(String name) throws CatalogException;
 

--- a/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
@@ -169,10 +169,11 @@ public final class JDOCatalogContext implements CatalogContext {
   }
 
   @Override
-  public MSynopsis createSynopsis(String synopsisName, String modelInstanceName)
-      throws CatalogException {
+  public MSynopsis createSynopsis(String synopsisName, String modelInstanceName, Integer rows,
+                                  @Nullable Double ratio) throws CatalogException {
     try {
-      MSynopsis mSynopsis = new MSynopsis(synopsisName, getModelInstance(modelInstanceName));
+      MSynopsis mSynopsis = new MSynopsis(
+          synopsisName, rows, ratio, getModelInstance(modelInstanceName));
       pm.makePersistent(mSynopsis);
       return mSynopsis;
     } catch (RuntimeException e) {

--- a/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
@@ -21,6 +21,7 @@ import java.util.List;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import javax.jdo.Transaction;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import traindb.catalog.pm.MModel;
 import traindb.catalog.pm.MModelInstance;
 import traindb.catalog.pm.MSynopsis;
@@ -100,10 +101,12 @@ public final class JDOCatalogContext implements CatalogContext {
   @Override
   public MModelInstance trainModelInstance(
       String modelName, String modelInstanceName, String schemaName, String tableName,
-      List<String> columnNames) throws CatalogException {
+      List<String> columnNames, @Nullable Long baseTableRows, @Nullable Long trainedRows)
+      throws CatalogException {
     try {
       MModelInstance mModelInstance = new MModelInstance(
-        getModel(modelName), modelInstanceName, schemaName, tableName, columnNames);
+          getModel(modelName), modelInstanceName, schemaName, tableName, columnNames,
+          baseTableRows, trainedRows);
       pm.makePersistent(mModelInstance);
       return mModelInstance;
     } catch (RuntimeException e) {

--- a/traindb-catalog/src/main/java/traindb/catalog/pm/MModelInstance.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/pm/MModelInstance.java
@@ -21,6 +21,7 @@ import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
 import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Unique;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import traindb.catalog.CatalogConstants;
 
 @PersistenceCapable
@@ -46,15 +47,24 @@ public final class MModelInstance {
   private String tableName;
 
   @Persistent
+  private long baseTableRows;
+
+  @Persistent
+  private long trainedRows;
+
+  @Persistent
   private List<String> columns;
 
-  public MModelInstance(MModel model, String modelInstanceName, String schemaName,
-                        String tableName, List<String> columns) {
+  public MModelInstance(
+      MModel model, String modelInstanceName, String schemaName, String tableName,
+      List<String> columns, @Nullable Long baseTableRows, @Nullable Long trainedRows) {
     this.model = model;
     this.name = modelInstanceName;
     this.schemaName = schemaName;
     this.tableName = tableName;
     this.columns = columns;
+    this.baseTableRows = (baseTableRows == null) ? 0 : baseTableRows;
+    this.trainedRows = (trainedRows == null) ? 0 : trainedRows;
   }
 
   public String getName() {
@@ -75,5 +85,13 @@ public final class MModelInstance {
 
   public List<String> getColumnNames() {
     return columns;
+  }
+
+  public long getBaseTableRows() {
+    return baseTableRows;
+  }
+
+  public long getTrainedRows() {
+    return trainedRows;
   }
 }

--- a/traindb-catalog/src/main/java/traindb/catalog/pm/MSynopsis.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/pm/MSynopsis.java
@@ -14,7 +14,6 @@
 
 package traindb.catalog.pm;
 
-import java.util.List;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
@@ -34,16 +33,32 @@ public final class MSynopsis {
   @Column(length = CatalogConstants.IDENTIFIER_MAX_LENGTH)
   private String name;
 
+  @Persistent
+  private int rows;
+
+  @Persistent
+  private double ratio;
+
   @Persistent(dependent = "false")
   private MModelInstance modelInstance;
 
-  public MSynopsis(String name, MModelInstance modelInstance) {
+  public MSynopsis(String name, Integer rows, Double ratio, MModelInstance modelInstance) {
     this.name = name;
+    this.rows = rows;
+    this.ratio = (ratio == null) ? 0 : ratio;
     this.modelInstance = modelInstance;
   }
 
   public String getName() {
     return name;
+  }
+
+  public int getRows() {
+    return rows;
+  }
+
+  public double getRatio() {
+    return ratio;
   }
 
   public MModelInstance getModelInstance() {

--- a/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
@@ -17,8 +17,10 @@ package traindb.engine;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.CSVWriter;
+import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.FileWriter;
+import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.PreparedStatement;
@@ -28,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 import traindb.catalog.CatalogContext;
 import traindb.catalog.CatalogException;
 import traindb.catalog.pm.MModel;
@@ -209,8 +212,15 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
     Process process = pb.start();
     process.waitFor();
 
+    String trainInfoFilename = outputPath + "/train_info.json";
+    JSONParser jsonParser = new JSONParser();
+    JSONObject jsonTrainInfo = (JSONObject) jsonParser.parse(new FileReader(trainInfoFilename));
+    Long base_table_rows = (Long) jsonTrainInfo.get("base_table_rows");
+    Long trained_rows = (Long) jsonTrainInfo.get("trained_rows");
+
     catalogContext.trainModelInstance(
-        modelName, modelInstanceName, schemaName, tableName, columnNames);
+        modelName, modelInstanceName, schemaName, tableName, columnNames,
+        base_table_rows, trained_rows);
   }
 
   @Override

--- a/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
@@ -17,10 +17,8 @@ package traindb.engine;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.CSVWriter;
-import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.FileWriter;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.PreparedStatement;
@@ -317,7 +315,8 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
     createSynopsisTable(synopsisName, mModelInstance);
     loadSynopsisIntoTable(synopsisName, mModelInstance, outputPath);
 
-    catalogContext.createSynopsis(synopsisName, modelInstanceName);
+    double ratio = (double) limitNumber / (double) mModelInstance.getBaseTableRows();
+    catalogContext.createSynopsis(synopsisName, modelInstanceName, limitNumber, ratio);
   }
 
   private void dropSynopsisTable(String synopsisName) throws Exception {


### PR DESCRIPTION
- Add columns in catalog tables
  - baseTableRows and trainedRows for MModelInstance
  - rows and ratio for MSynopsis
- Use the synopsis ratio information in ApproxAggregateSynopsisProjectScanRule
