### PR TITLE
Approximate query using inference models

### DIFF
--- a/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
@@ -44,6 +44,9 @@ public interface CatalogContext {
 
   Collection<MModel> getModels() throws CatalogException;
 
+  Collection<MModel> getInferenceModels(String baseSchema, String baseTable)
+      throws CatalogException;
+
   boolean modelExists(String name);
 
   MModel getModel(String name);

--- a/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
@@ -14,7 +14,6 @@
 
 package traindb.catalog;
 
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import traindb.catalog.pm.MModel;
@@ -50,8 +49,6 @@ public interface CatalogContext {
   boolean modelExists(String name);
 
   MModel getModel(String name);
-
-  Path getModelPath(String modeltypeName, String modelName);
 
   MSynopsis createSynopsis(String synopsisName, String modelName, Integer rows, Double ratio)
       throws CatalogException;

--- a/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
@@ -140,6 +140,20 @@ public final class JDOCatalogContext implements CatalogContext {
   }
 
   @Override
+  public Collection<MModel> getInferenceModels(String baseSchema, String baseTable)
+      throws CatalogException {
+    try {
+      Query query = pm.newQuery(MModel.class);
+      query.setFilter(
+          "schemaName == baseSchema && tableName == baseTable && modeltype.type == \"INFERENCE\"");
+      query.declareParameters("String baseSchema, String baseTable");
+      return (List<MModel>) query.execute(baseSchema, baseTable);
+    } catch (RuntimeException e) {
+      throw new CatalogException("failed to get models", e);
+    }
+  }
+
+  @Override
   public boolean modelExists(String name) {
     return getModel(name) != null;
   }

--- a/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
@@ -14,8 +14,6 @@
 
 package traindb.catalog;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 import javax.jdo.PersistenceManager;
@@ -25,7 +23,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import traindb.catalog.pm.MModel;
 import traindb.catalog.pm.MModeltype;
 import traindb.catalog.pm.MSynopsis;
-import traindb.common.TrainDBConfiguration;
 import traindb.common.TrainDBLogger;
 
 public final class JDOCatalogContext implements CatalogContext {
@@ -169,12 +166,6 @@ public final class JDOCatalogContext implements CatalogContext {
       return (MModel) query.execute(name);
     } catch (RuntimeException e) { }
     return null;
-  }
-
-  @Override
-  public Path getModelPath(String modeltypeName, String modelName) {
-    return Paths.get(TrainDBConfiguration.getTrainDBPrefixPath(), "models",
-                     modeltypeName, modelName);
   }
 
   @Override

--- a/traindb-core/pom.xml
+++ b/traindb-core/pom.xml
@@ -131,6 +131,10 @@ limitations under the License.
             <groupId>net.sf.py4j</groupId>
             <artifactId>py4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.sf.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+        </dependency>
 
         <!--  Test Support -->
         <dependency>

--- a/traindb-core/src/main/java/traindb/adapter/python/PythonMLAggregate.java
+++ b/traindb-core/src/main/java/traindb/adapter/python/PythonMLAggregate.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.adapter.python;
+
+import com.google.common.collect.ImmutableList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.InvalidRelException;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import traindb.catalog.pm.MModel;
+
+/**
+ * Implementation of {@link Aggregate} relational expression for Python ML.
+ */
+public class PythonMLAggregate extends Aggregate implements PythonRel {
+
+  private static final Set<SqlKind> SUPPORTED_AGGREGATIONS =
+      EnumSet.of(SqlKind.COUNT, SqlKind.AVG, SqlKind.SUM, SqlKind.STDDEV_POP, SqlKind.VAR_POP,
+          SqlKind.ANY_VALUE);
+
+  final MModel model;
+
+  public PythonMLAggregate(RelOptCluster cluster,
+                           RelTraitSet traitSet,
+                           RelNode input,
+                           ImmutableBitSet groupSet,
+                           List<ImmutableBitSet> groupSets,
+                           List<AggregateCall> aggCalls,
+                           MModel model) throws InvalidRelException {
+    super(cluster, traitSet, ImmutableList.of(), input, groupSet, groupSets, aggCalls);
+    this.model = model;
+
+    assert this.groupSets.size() == 1 : "Grouping sets not supported";
+
+    for (AggregateCall aggCall : aggCalls) {
+      final SqlKind kind = aggCall.getAggregation().getKind();
+      if (!SUPPORTED_AGGREGATIONS.contains(kind)) {
+        final String message = String.format(Locale.ROOT,
+            "Aggregation %s not supported (use one of %s)", kind, SUPPORTED_AGGREGATIONS);
+        throw new InvalidRelException(message);
+      }
+    }
+
+    if (getGroupType() != Group.SIMPLE) {
+      final String message = String.format(Locale.ROOT, "Only %s grouping is supported. "
+          + "Yours is %s", Group.SIMPLE, getGroupType());
+      throw new InvalidRelException(message);
+    }
+  }
+
+  @Override
+  public Aggregate copy(RelTraitSet traitSet, RelNode input,
+                        ImmutableBitSet groupSet, List<ImmutableBitSet> groupSets,
+                        List<AggregateCall> aggCalls) {
+    try {
+      return new PythonMLAggregate(getCluster(), traitSet, input,
+          groupSet, groupSets, aggCalls, model);
+    } catch (InvalidRelException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  @Override
+  public @Nullable RelOptCost computeSelfCost(RelOptPlanner planner,
+                                              RelMetadataQuery mq) {
+    return super.computeSelfCost(planner, mq).multiplyBy(0.1);
+  }
+
+  @Override
+  public void register(RelOptPlanner planner) {
+    planner.addRule(PythonToEnumerableConverterRule.INSTANCE);
+  }
+
+  @Override
+  public Result implement() {
+    Result result = ((PythonRel) getInput()).implement();
+    return result;
+  }
+
+}

--- a/traindb-core/src/main/java/traindb/adapter/python/PythonMLAggregateEnumerable.java
+++ b/traindb-core/src/main/java/traindb/adapter/python/PythonMLAggregateEnumerable.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.adapter.python;
+
+import au.com.bytecode.opencsv.CSVReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.linq4j.AbstractEnumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class PythonMLAggregateEnumerable extends AbstractEnumerable<Object[]> {
+
+  public final String csvResultPath;
+  public final Map<String, SqlTypeName> fields;
+
+  public PythonMLAggregateEnumerable(String csvResultPath, Map<String, SqlTypeName> fields) {
+    this.csvResultPath = csvResultPath;
+    this.fields = fields;
+  }
+
+  @Override
+  public Enumerator<Object[]> enumerator() {
+    return Linq4j.enumerator(inferResult());
+  }
+
+  private List<Object[]> inferResult() {
+    try (CSVReader csvReader = new CSVReader(new FileReader(csvResultPath))) {
+      List<Object[]> result = new ArrayList<>();
+      String[] line;
+      while ((line = csvReader.readNext()) != null) {
+        Object[] row = new Object[fields.size()];
+        int i = 0;
+        for (Map.Entry<String, SqlTypeName> field : fields.entrySet()) {
+          row[i] = convert(field.getValue(), line[i]);
+          i++;
+        }
+        result.add(row);
+      }
+      return result;
+    } catch (IOException exception) {
+      return Collections.emptyList();
+    }
+  }
+
+  private @Nullable Object convert(SqlTypeName fieldType, @Nullable String string) {
+    switch (fieldType) {
+      case BOOLEAN:
+        if (string.length() == 0) {
+          return null;
+        }
+        return Boolean.parseBoolean(string);
+      case TINYINT:
+        if (string.length() == 0) {
+          return null;
+        }
+        return Byte.parseByte(string);
+      case SMALLINT:
+        if (string.length() == 0) {
+          return null;
+        }
+        return Short.parseShort(string);
+      case INTEGER:
+        if (string.length() == 0) {
+          return null;
+        }
+        return (int) Double.parseDouble(string);
+      case BIGINT:
+        if (string.length() == 0) {
+          return null;
+        }
+        return (long) Double.parseDouble(string);
+      case FLOAT:
+        if (string.length() == 0) {
+          return null;
+        }
+        return Float.parseFloat(string);
+      case DOUBLE:
+      case DECIMAL:
+        if (string.length() == 0) {
+          return null;
+        }
+        return Double.parseDouble(string);
+      case DATE:
+      case TIME:
+      case TIMESTAMP:
+      case VARCHAR:
+      default:
+        return string;
+    }
+  }
+
+}

--- a/traindb-core/src/main/java/traindb/adapter/python/PythonMLAggregateModel.java
+++ b/traindb-core/src/main/java/traindb/adapter/python/PythonMLAggregateModel.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.adapter.python;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.DataContext;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexSqlStandardConvertletTable;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.ImmutableBitSet;
+import traindb.engine.AbstractTrainDBModelRunner;
+
+public class PythonMLAggregateModel extends AbstractTable implements ScannableTable {
+
+  public final AbstractTrainDBModelRunner runner;
+  public final List<AggregateCall> aggCalls;
+  public final ImmutableBitSet groupSet;
+  public final RelDataType inputRowType;
+  public final Map<RexNode, RelDataType> filterConditionMap;
+  public final RelDataType rowType;
+
+  public PythonMLAggregateModel(
+      AbstractTrainDBModelRunner runner, List<AggregateCall> aggCalls, ImmutableBitSet groupSet,
+      RelDataType inputRowType, Map<RexNode, RelDataType> filterConditionMap, RelDataType rowType) {
+    this.runner = runner;
+    this.aggCalls = aggCalls;
+    this.groupSet = groupSet;
+    this.inputRowType = inputRowType;
+    this.filterConditionMap = filterConditionMap;
+    this.rowType = rowType;
+  }
+
+  @Override
+  public Enumerable<Object[]> scan(DataContext root) {
+    String csvResultPath = doInfer();
+    Map<String, SqlTypeName> fieldsMap = new LinkedHashMap<>();
+    for (RelDataTypeField f : rowType.getFieldList()) {
+      fieldsMap.put(f.getName(), f.getType().getSqlTypeName());
+    }
+
+    return new PythonMLAggregateEnumerable(csvResultPath, fieldsMap);
+  }
+
+  @Override
+  public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+    return typeFactory.copyType(rowType);
+  }
+
+  public String doInfer() {
+    PythonRexToSqlNodeConverterImpl rexToSqlNodeConverter =
+        new PythonRexToSqlNodeConverterImpl(new RexSqlStandardConvertletTable());
+
+    List<String> aggregateExpressions = new ArrayList<>();
+    List<String> inputFields = inputRowType.getFieldNames();
+    List<String> aggCallFieldNames = new ArrayList<>();
+    for (AggregateCall aggCall : aggCalls) {
+      aggCallFieldNames.clear();
+      for (int i : aggCall.getArgList()) {
+        aggCallFieldNames.add(inputFields.get(i));
+      }
+      String aggrFuncName = aggCall.getAggregation().getName();
+      if ("COUNT".equalsIgnoreCase(aggrFuncName) && aggCallFieldNames.isEmpty()) {
+        aggCallFieldNames.add("*");
+      }
+      aggregateExpressions.add(buildString(aggCallFieldNames, aggrFuncName + "(", ",", ")"));
+    }
+    if (aggregateExpressions.size() > 1) {
+      throw new UnsupportedOperationException(
+          "Two or more aggregate expressions are not supported yet.");
+    }
+
+    List<String> groupColumns = getGroupColumnNames(groupSet, inputRowType);
+    if (groupColumns.size() > 1) {
+      throw new UnsupportedOperationException(
+          "Two or more group columns are not supported yet.");
+    }
+
+    List<String> filterConditions = new ArrayList<>();
+    for (Map.Entry<RexNode, RelDataType> entry : filterConditionMap.entrySet()) {
+      rexToSqlNodeConverter.setInputcolumns(entry.getValue().getFieldNames());
+      SqlNode sqlNode = rexToSqlNodeConverter.convertCall((RexCall) entry.getKey());
+      filterConditions.add(sqlNode.toSqlString(AnsiSqlDialect.DEFAULT).toString().replace("`", ""));
+    }
+    if (filterConditions.size() > 1) {
+      throw new UnsupportedOperationException(
+          "Two or more filter conditions are not supported yet.");
+    }
+
+    String aggregate = aggregateExpressions.get(0);
+    String groupBy = groupColumns.isEmpty() ? "" : groupColumns.get(0);
+    String whereCondition = filterConditions.isEmpty() ? "" : filterConditions.get(0);
+
+    String resultCsvPath;
+    try {
+      resultCsvPath = runner.infer(aggregate, groupBy, whereCondition);
+    } catch (Exception e) {
+      throw new RuntimeException("failed to infer expression '" + aggregate + "'");
+    }
+    return resultCsvPath;
+  }
+
+  private List<String> getGroupColumnNames(ImmutableBitSet groupSet, RelDataType inputRowType) {
+    List<String> groupColumnNames = new ArrayList<>();
+    final List<Integer> groupList = groupSet.asList();
+    final List<RelDataTypeField> fieldList = inputRowType.getFieldList();
+    for (int groupKey : groupList) {
+      final RelDataTypeField field = fieldList.get(groupKey);
+      groupColumnNames.add(field.getName());
+    }
+    return groupColumnNames;
+  }
+
+  private String buildString(Collection<String> items, String start, String sep, String end) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(start);
+    for (String item : items) {
+      sb.append(item);
+      sb.append(sep);
+    }
+    if (items.size() > 0) {
+      sb.setLength(sb.length() - 1);
+    }
+    sb.append(end);
+    return sb.toString();
+  }
+}

--- a/traindb-core/src/main/java/traindb/adapter/python/PythonMLAggregateModelScan.java
+++ b/traindb-core/src/main/java/traindb/adapter/python/PythonMLAggregateModelScan.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.adapter.python;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class PythonMLAggregateModelScan extends TableScan implements PythonRel {
+
+  PythonMLAggregateModel pyModel;
+
+  public PythonMLAggregateModelScan(RelOptCluster cluster, RelTraitSet traitSet,
+                                    RelOptTable table, PythonMLAggregateModel pyModel) {
+    super(cluster, traitSet, ImmutableList.of(), table);
+    this.pyModel = pyModel;
+
+    assert getConvention() == PythonRel.CONVENTION;
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    assert inputs.isEmpty();
+    return this;
+  }
+
+  @Override
+  public @Nullable RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+    return super.computeSelfCost(planner, mq).multiplyBy(.01);
+  }
+
+  @Override
+  public void register(RelOptPlanner planner) {
+    planner.addRule(PythonToEnumerableConverterRule.INSTANCE);
+  }
+
+  @Override
+  public Result implement() {
+    return new Result(pyModel);
+  }
+}

--- a/traindb-core/src/main/java/traindb/adapter/python/PythonRel.java
+++ b/traindb-core/src/main/java/traindb/adapter/python/PythonRel.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.adapter.python;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.rel.RelNode;
+
+/**
+ * Relational expression that uses Python calling convention.
+ */
+public interface PythonRel extends RelNode {
+
+  Convention CONVENTION = new Convention.Impl("PYTHON", PythonRel.class);
+
+  Result implement();
+
+  class Result {
+
+    public final PythonMLAggregateModel pyModel;
+
+    public Result(PythonMLAggregateModel pyModel) {
+      this.pyModel = pyModel;
+    }
+  }
+
+}

--- a/traindb-core/src/main/java/traindb/adapter/python/PythonRexToSqlNodeConverterImpl.java
+++ b/traindb-core/src/main/java/traindb/adapter/python/PythonRexToSqlNodeConverterImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.adapter.python;
+
+import java.util.List;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexSqlConvertletTable;
+import org.apache.calcite.rex.RexToSqlNodeConverterImpl;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+public class PythonRexToSqlNodeConverterImpl extends RexToSqlNodeConverterImpl {
+
+  private List<String> inputColumns;
+
+  public PythonRexToSqlNodeConverterImpl(RexSqlConvertletTable convertletTable) {
+    super(convertletTable);
+    this.inputColumns = null;
+  }
+
+  public void setInputcolumns(List<String> inputColumns) {
+    this.inputColumns = inputColumns;
+  }
+
+  @Override
+  public @Nullable SqlNode convertNode(RexNode node) {
+    if (node instanceof RexLiteral) {
+      return convertLiteral((RexLiteral) node);
+    } else if (node instanceof RexInputRef) {
+      return convertInputRef((RexInputRef) node, inputColumns);
+    } else if (node instanceof RexCall) {
+      return convertCall((RexCall) node);
+    }
+    return null;
+  }
+
+  public @Nullable SqlNode convertInputRef(RexInputRef ref, @Nullable List<String> inputColumns) {
+    if (inputColumns == null) {
+      return convertInputRef(ref);
+    }
+    String column = inputColumns.get(ref.getIndex());
+    return new SqlIdentifier(column, SqlParserPos.ZERO);
+  }
+}

--- a/traindb-core/src/main/java/traindb/adapter/python/PythonToEnumerableConverter.java
+++ b/traindb-core/src/main/java/traindb/adapter/python/PythonToEnumerableConverter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.adapter.python;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.adapter.enumerable.EnumerableConvention;
+import org.apache.calcite.adapter.enumerable.EnumerableRel;
+import org.apache.calcite.adapter.enumerable.EnumerableRelImplementor;
+import org.apache.calcite.adapter.enumerable.JavaRowFormat;
+import org.apache.calcite.adapter.enumerable.PhysType;
+import org.apache.calcite.adapter.enumerable.PhysTypeImpl;
+import org.apache.calcite.linq4j.tree.BlockBuilder;
+import org.apache.calcite.linq4j.tree.ConstantExpression;
+import org.apache.calcite.linq4j.tree.DeclarationStatement;
+import org.apache.calcite.linq4j.tree.Expression;
+import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.linq4j.tree.MethodCallExpression;
+import org.apache.calcite.linq4j.tree.NewExpression;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.plan.RelOptCost;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterImpl;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Relational expression representing a result table from a Python ML runner.
+ */
+public class PythonToEnumerableConverter extends ConverterImpl implements EnumerableRel {
+
+  PythonToEnumerableConverter(RelNode input) {
+    super(input.getCluster(), ConventionTraitDef.INSTANCE,
+        input.getCluster().traitSetOf(EnumerableConvention.INSTANCE), input);
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
+    return new PythonToEnumerableConverter(inputs.get(0));
+  }
+
+  @Override
+  public @Nullable RelOptCost computeSelfCost(RelOptPlanner planner, RelMetadataQuery mq) {
+    return super.computeSelfCost(planner, mq).multiplyBy(.1);
+  }
+
+  @Override
+  public Result implement(EnumerableRelImplementor implementor, Prefer prefer) {
+    final PythonMLAggregateModel pyModel = ((PythonRel) input).implement().pyModel;
+    String csvResultPath = pyModel.doInfer();
+
+    try {
+      BlockBuilder codeBlock = new BlockBuilder();
+      DeclarationStatement fieldStmt =
+          Expressions.declare(0, "fields", Expressions.new_(LinkedHashMap.class));
+      codeBlock.add(fieldStmt);
+      Method putMethod = Map.class.getMethod("put", Object.class, Object.class);
+      for (RelDataTypeField f : getRowType().getFieldList()) {
+        ConstantExpression fieldName = Expressions.constant(f.getName());
+        ConstantExpression fieldType = Expressions.constant(f.getType().getSqlTypeName());
+        MethodCallExpression callPut =
+            Expressions.call(fieldStmt.parameter, putMethod, fieldName, fieldType);
+        codeBlock.add(Expressions.statement(callPut));
+      }
+
+      Expression exprCsvResultPath =
+          codeBlock.append("csvResultPath", Expressions.constant(csvResultPath, String.class));
+
+      NewExpression pyEnumerable = Expressions.new_(PythonMLAggregateEnumerable.class,
+          exprCsvResultPath, fieldStmt.parameter);
+      codeBlock.add(Expressions.return_(null, pyEnumerable));
+      PhysType physType = PhysTypeImpl.of(implementor.getTypeFactory(), getRowType(),
+          prefer.prefer(JavaRowFormat.ARRAY));
+      return implementor.result(physType, codeBlock.toBlock());
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/traindb-core/src/main/java/traindb/adapter/python/PythonToEnumerableConverterRule.java
+++ b/traindb-core/src/main/java/traindb/adapter/python/PythonToEnumerableConverterRule.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.adapter.python;
+
+import org.apache.calcite.adapter.enumerable.EnumerableConvention;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+
+/**
+ * Rule to convert a relational expression from
+ * {@link PythonRel#CONVENTION} to {@link EnumerableConvention}.
+ */
+public class PythonToEnumerableConverterRule extends ConverterRule {
+  /**
+   * Singleton instance of PythonToEnumerableConverterRule.
+   */
+  static final ConverterRule INSTANCE = Config.INSTANCE
+      .withConversion(RelNode.class, PythonRel.CONVENTION,
+          EnumerableConvention.INSTANCE,
+          "PythonToEnumerableConverterRule")
+      .withRuleFactory(PythonToEnumerableConverterRule::new)
+      .toRule(PythonToEnumerableConverterRule.class);
+
+  /**
+   * Called from the Config.
+   */
+  protected PythonToEnumerableConverterRule(Config config) {
+    super(config);
+  }
+
+  @Override
+  public RelNode convert(RelNode relNode) {
+    return new PythonToEnumerableConverter(relNode);
+  }
+}

--- a/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
+++ b/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
@@ -15,12 +15,14 @@
 package traindb.engine;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.ResultSet;
 import java.sql.Types;
 import java.util.List;
 import java.util.Map;
 import org.json.simple.JSONObject;
 import traindb.catalog.CatalogContext;
+import traindb.common.TrainDBConfiguration;
 import traindb.jdbc.TrainDBConnectionImpl;
 
 public abstract class AbstractTrainDBModelRunner {
@@ -44,7 +46,8 @@ public abstract class AbstractTrainDBModelRunner {
   public abstract void generateSynopsis(String synopsisName, int rows) throws Exception;
 
   public Path getModelPath() {
-    return catalogContext.getModelPath(modeltypeName, modelName);
+    return Paths.get(TrainDBConfiguration.getTrainDBPrefixPath(), "models",
+        modeltypeName, modelName);
   }
 
   protected String buildSelectTrainingDataQuery(String schemaName, String tableName,

--- a/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
+++ b/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
@@ -45,6 +45,9 @@ public abstract class AbstractTrainDBModelRunner {
 
   public abstract void generateSynopsis(String synopsisName, int rows) throws Exception;
 
+  public abstract String infer(String aggregateExpression, String groupByColumn,
+                               String whereCondition) throws Exception;
+
   public Path getModelPath() {
     return Paths.get(TrainDBConfiguration.getTrainDBPrefixPath(), "models",
         modeltypeName, modelName);

--- a/traindb-core/src/main/java/traindb/engine/TrainDBPy4JModelRunner.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBPy4JModelRunner.java
@@ -126,6 +126,12 @@ public class TrainDBPy4JModelRunner extends AbstractTrainDBModelRunner {
     process.destroy();
   }
 
+  @Override
+  public String infer(String aggregateExpression, String groupByColumn, String whereCondition)
+      throws Exception {
+    throw new TrainDBException("Not supported yet in Py4J model runner");
+  }
+
   private int getAvailablePort() throws Exception {
     ServerSocket s;
     try {

--- a/traindb-core/src/main/java/traindb/planner/TrainDBPlanner.java
+++ b/traindb-core/src/main/java/traindb/planner/TrainDBPlanner.java
@@ -62,6 +62,7 @@ public class TrainDBPlanner extends VolcanoPlanner {
     addRule(TrainDBRules.APPROX_AGGREGATE_SYNOPSIS_PROJECT_SCAN);
     addRule(TrainDBRules.APPROX_AGGREGATE_SYNOPSIS_FILTER_SCAN);
     addRule(TrainDBRules.APPROX_AGGREGATE_SYNOPSIS_AGGREGATE_SCAN);
+    addRule(TrainDBRules.APPROX_AGGREGATE_INFERENCE);
 
     RelOptUtil.registerDefaultRules(this, true, Hook.ENABLE_BINDABLE.get(false));
     addRelTraitDef(ConventionTraitDef.INSTANCE);
@@ -69,6 +70,10 @@ public class TrainDBPlanner extends VolcanoPlanner {
     setTopDownOpt(false);
 
     Hook.PLANNER.run(this); // allow test to add or remove rules
+  }
+
+  public CatalogContext getCatalogContext() {
+    return catalogContext;
   }
 
   public Collection<MSynopsis> getAvailableSynopses(List<String> qualifiedBaseTableName,

--- a/traindb-core/src/main/java/traindb/planner/TrainDBPlanner.java
+++ b/traindb-core/src/main/java/traindb/planner/TrainDBPlanner.java
@@ -29,6 +29,7 @@ import org.apache.calcite.runtime.Hook;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import traindb.catalog.CatalogContext;
 import traindb.catalog.CatalogException;
+import traindb.catalog.pm.MModel;
 import traindb.catalog.pm.MSynopsis;
 import traindb.planner.rules.TrainDBRules;
 import traindb.prepare.TrainDBCatalogReader;
@@ -106,4 +107,24 @@ public class TrainDBPlanner extends VolcanoPlanner {
     MSynopsis bestSynopsis = synopses.iterator().next();
     return bestSynopsis;
   }
+
+  public Collection<MModel> getAvailableInferenceModels(
+      List<String> qualifiedBaseTableName, List<String> requiredColumnNames) {
+    String baseSchema = qualifiedBaseTableName.get(1);
+    String baseTable = qualifiedBaseTableName.get(2);
+    try {
+      Collection<MModel> models = catalogContext.getInferenceModels(baseSchema, baseTable);
+      List<MModel> availableModels = new ArrayList<>();
+      for (MModel model : models) {
+        List<String> columnNames = model.getColumnNames();
+        if (columnNames.containsAll(requiredColumnNames)) {
+          availableModels.add(model);
+        }
+      }
+      return availableModels;
+    } catch (CatalogException e) {
+    }
+    return null;
+  }
+
 }

--- a/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateInferenceRule.java
+++ b/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateInferenceRule.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.planner.rules;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.InvalidRelException;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.core.TableScan;
+import org.apache.calcite.rel.rules.SubstitutionRule;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
+import org.immutables.value.Value;
+import traindb.adapter.python.PythonMLAggregate;
+import traindb.adapter.python.PythonMLAggregateModel;
+import traindb.adapter.python.PythonMLAggregateModelScan;
+import traindb.adapter.python.PythonRel;
+import traindb.catalog.pm.MModel;
+import traindb.engine.AbstractTrainDBModelRunner;
+import traindb.engine.TrainDBFileModelRunner;
+import traindb.planner.TrainDBPlanner;
+
+@Value.Enclosing
+public class ApproxAggregateInferenceRule
+    extends RelRule<ApproxAggregateInferenceRule.Config>
+    implements SubstitutionRule {
+
+  protected ApproxAggregateInferenceRule(Config config) {
+    super(config);
+  }
+
+  @Override
+  public boolean autoPruneOld() {
+    return true;
+  }
+
+  //~ Methods ----------------------------------------------------------------
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    if (!(call.getPlanner() instanceof TrainDBPlanner)) {
+      return;
+    }
+    final TrainDBPlanner planner = (TrainDBPlanner) call.getPlanner();
+    final RelBuilder relBuilder = call.builder();
+
+    final Aggregate aggregate = call.rel(0);
+    List<Integer> requiredColumnIndex = new ArrayList<>();
+    for (AggregateCall aggCall : aggregate.getAggCallList()) {
+      requiredColumnIndex.addAll(aggCall.getArgList());
+    }
+    int aggColumnSize = requiredColumnIndex.size();
+
+    List<TableScan> tableScans = ApproxAggregateUtil.findAllTableScans(aggregate);
+    if (tableScans.size() != 1) {
+      return;
+    }
+    TableScan scan = tableScans.get(0);
+    if (!ApproxAggregateUtil.isApproximateTableScan(scan)) {
+      return;
+    }
+
+    requiredColumnIndex.subList(aggColumnSize, requiredColumnIndex.size()).clear();
+
+    RelDataType inputRowType = scan.getRowType();
+    Map<RexNode, RelDataType> filterConditionMap = new HashMap<>();
+    RelNode parent = ApproxAggregateUtil.getParent(aggregate, scan);
+    while (parent != aggregate) {
+      if (parent instanceof Project) {
+        inputRowType = parent.getRowType();
+      } else if (parent instanceof Filter) {
+        Filter filter = (Filter) parent;
+        filterConditionMap.put(filter.getCondition(), inputRowType);
+
+        List<RexNode> rexNodes = ((RexCall) filter.getCondition()).getOperands();
+        for (RexNode rexNode : rexNodes) {
+          if (rexNode instanceof RexCall) {
+            rexNode = ((RexCall) rexNode).getOperands().get(0);
+          }
+          if (rexNode instanceof RexInputRef) {
+            requiredColumnIndex.add(((RexInputRef) rexNode).getIndex());
+          }
+        }
+      }
+      parent = ApproxAggregateUtil.getParent(aggregate, parent);
+    }
+
+    List<String> requiredColumnNames =
+        ApproxAggregateUtil.getSublistByIndex(inputRowType.getFieldNames(), requiredColumnIndex);
+    Collection<MModel> candidateModels =
+        planner.getAvailableInferenceModels(scan.getTable().getQualifiedName(),
+            requiredColumnNames);
+    if (candidateModels == null || candidateModels.isEmpty()) {
+      return;
+    }
+
+    // TODO choose the best inference model
+    final MModel bestInferenceModel = candidateModels.iterator().next();
+
+    AbstractTrainDBModelRunner runner =
+        new TrainDBFileModelRunner(null, planner.getCatalogContext(),
+            bestInferenceModel.getModeltype().getName(), bestInferenceModel.getName());
+
+    PythonMLAggregateModel modelTable = new PythonMLAggregateModel(runner,
+        aggregate.getAggCallList(), aggregate.getGroupSet(), aggregate.getInput().getRowType(),
+        filterConditionMap, aggregate.getRowType());
+    PythonMLAggregate mlAgg;
+    try {
+      RelOptCluster cluster = aggregate.getCluster();
+      mlAgg = new PythonMLAggregate(
+          cluster, cluster.traitSetOf(PythonRel.CONVENTION),
+          new PythonMLAggregateModelScan(
+              cluster, cluster.traitSetOf(PythonRel.CONVENTION), scan.getTable(), modelTable),
+          aggregate.getGroupSet(), aggregate.getGroupSets(), aggregate.getAggCallList(),
+          bestInferenceModel);
+      mlAgg.register(planner);
+    } catch (InvalidRelException e) {
+      return;
+    }
+
+    RelNode node = relBuilder.push(mlAgg).build();
+    call.transformTo(node);
+  }
+
+  /**
+   * Rule configuration.
+   */
+  @Value.Immutable(singleton = true)
+  public interface Config extends RelRule.Config {
+    Config DEFAULT = ImmutableApproxAggregateInferenceRule.Config.of()
+        .withOperandSupplier(b0 ->
+            b0.operand(Aggregate.class)
+                .predicate(ApproxAggregateUtil::isApproximateAggregate)
+                .predicate(ApproxAggregateUtil::hasApproxAggregateFunctionsOnly)
+                .anyInputs());
+
+    @Override
+    default ApproxAggregateInferenceRule toRule() {
+      return new ApproxAggregateInferenceRule(this);
+    }
+  }
+}

--- a/traindb-core/src/main/java/traindb/planner/rules/TrainDBRules.java
+++ b/traindb-core/src/main/java/traindb/planner/rules/TrainDBRules.java
@@ -30,4 +30,8 @@ public class TrainDBRules {
   public static final ApproxAggregateSynopsisAggregateScanRule
       APPROX_AGGREGATE_SYNOPSIS_AGGREGATE_SCAN =
       ApproxAggregateSynopsisAggregateScanRule.Config.DEFAULT.toRule();
+
+  public static final ApproxAggregateInferenceRule
+      APPROX_AGGREGATE_INFERENCE =
+      ApproxAggregateInferenceRule.Config.DEFAULT.toRule();
 }

--- a/traindb-model/src/main/python/TrainDBCliModelRunner.py
+++ b/traindb-model/src/main/python/TrainDBCliModelRunner.py
@@ -79,6 +79,7 @@ parser_synopsis.add_argument('model_path', type=str, help='(str) path to model')
 parser_synopsis.add_argument('agg_expr', type=str, help='(str) aggregation expression')
 parser_synopsis.add_argument('group_by_column', type=str, help='(str) column specified in GROUP BY clause')
 parser_synopsis.add_argument('where_condition', type=str, help='(str) filter condition specified in WHERE clause')
+parser_synopsis.add_argument('output_file', type=str, nargs='?', default='', help='(str) path to save inferred query result file')
 
 args = root_parser.parse_args()
 runner = TrainDBCliModelRunner()
@@ -95,7 +96,13 @@ elif args.cmd == 'synopsis':
   syn_data.to_csv(args.output_file, index=False)
   sys.exit(0)
 elif args.cmd == 'infer':
-  syn_data = runner.infer(args.modeltype_class, args.modeltype_uri, args.model_path, args.agg_expr, args.group_by_column, args.where_condition)
+  aqp_result, confidence_interval = runner.infer(args.modeltype_class, args.modeltype_uri, args.model_path, args.agg_expr, args.group_by_column, args.where_condition)
+  if args.output_file == '':
+    print(aqp_result)
+  else:
+    with open(args.output_file, 'w') as f:
+      writer = csv.writer(f)
+      writer.writerows(aqp_result)
   sys.exit(0)
 else:
   root_parser.print_help()

--- a/traindb-model/src/main/python/TrainDBCliModelRunner.py
+++ b/traindb-model/src/main/python/TrainDBCliModelRunner.py
@@ -55,6 +55,7 @@ import argparse
 import pandas as pd
 import json
 import sys
+import csv
 
 root_parser = argparse.ArgumentParser(description='TrainDB CLI Model Runner')
 subparsers = root_parser.add_subparsers(dest='cmd')

--- a/traindb-project/pom.xml
+++ b/traindb-project/pom.xml
@@ -232,6 +232,11 @@ limitations under the License.
                 <artifactId>py4j</artifactId>
                 <version>0.10.9.7</version>
             </dependency>
+            <dependency>
+                <groupId>net.sf.opencsv</groupId>
+                <artifactId>opencsv</artifactId>
+                <version>2.3</version>
+            </dependency>
 
             <!--  Test Support -->
             <dependency>


### PR DESCRIPTION
I added the initial version of transformation rules and execution operators for inference models.
The RSPN model in our traindb-model repository supports simple aggregate queries with single aggregate function, single group-by column, and single filter condition.