### PR TITLE
feat: Add a command to list modeltype hyperparameters

### DIFF
--- a/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
@@ -35,7 +35,7 @@ public interface CatalogContext {
   Collection<MModeltype> getModeltypes(Map<String, Object> filterPatterns) throws CatalogException;
 
   MModeltype createModeltype(String name, String type, String location, String className,
-                             String uri) throws CatalogException;
+                             String uri, String hyperparameters) throws CatalogException;
 
   void dropModeltype(String name) throws CatalogException;
 

--- a/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
@@ -75,9 +75,9 @@ public final class JDOCatalogContext implements CatalogContext {
 
   @Override
   public MModeltype createModeltype(String name, String type, String location, String className,
-                                    String uri) throws CatalogException {
+                                    String uri, String hyperparameters) throws CatalogException {
     try {
-      MModeltype mModeltype = new MModeltype(name, type, location, className, uri);
+      MModeltype mModeltype = new MModeltype(name, type, location, className, uri, hyperparameters);
       pm.makePersistent(mModeltype);
       return mModeltype;
     } catch (RuntimeException e) {

--- a/traindb-catalog/src/main/java/traindb/catalog/pm/MModeltype.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/pm/MModeltype.java
@@ -51,15 +51,17 @@ public final class MModeltype {
   @Column(length = CatalogConstants.CONNECTION_STRING_MAX_LENGTH)
   private String uri;
 
-  @Persistent(mappedBy = "modeltype", dependentElement = "true")
-  private Collection<MModel> model;
+  @Persistent
+  private byte[] hyperparameters;
 
-  public MModeltype(String name, String type, String location, String className, String uri) {
+  public MModeltype(String name, String type, String location, String className, String uri,
+                    String hyperparameters) {
     this.modeltype_name = name;
     this.category = type;
     this.location = location;
     this.class_name = className;
     this.uri = uri;
+    this.hyperparameters = hyperparameters.getBytes();
   }
 
   public String getModeltypeName() {
@@ -82,7 +84,7 @@ public final class MModeltype {
     return uri;
   }
 
-  public Collection<MModel> getModel() {
-    return new ArrayList<MModel>(model);
+  public String getHyperparameters() {
+    return new String(hyperparameters);
   }
 }

--- a/traindb-core/src/main/antlr4/traindb/sql/TrainDBSql.g4
+++ b/traindb-core/src/main/antlr4/traindb/sql/TrainDBSql.g4
@@ -124,6 +124,7 @@ showTargets
     | K_SYNOPSES
     | K_SCHEMAS
     | K_TABLES
+    | K_HYPERPARAMETERS
     | K_QUERYLOGS
     | K_TASKS
     ;
@@ -219,6 +220,7 @@ K_DESCRIBE : D E S C R I B E ;
 K_DROP : D R O P ;
 K_FOR : F O R ;
 K_FROM : F R O M ;
+K_HYPERPARAMETERS : H Y P E R P A R A M E T E R S ;
 K_IN : I N ;
 K_INFERENCE : I N F E R E N C E ;
 K_LIKE : L I K E ;

--- a/traindb-core/src/main/antlr4/traindb/sql/TrainDBSql.g4
+++ b/traindb-core/src/main/antlr4/traindb/sql/TrainDBSql.g4
@@ -208,6 +208,7 @@ error
         }
     ;
 
+K_AND : A N D ;
 K_AS : A S ;
 K_BYPASS : B Y P A S S ;
 K_CLASS : C L A S S ;

--- a/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
+++ b/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
@@ -48,6 +48,8 @@ public abstract class AbstractTrainDBModelRunner {
   public abstract String infer(String aggregateExpression, String groupByColumn,
                                String whereCondition) throws Exception;
 
+  public abstract String listHyperparameters(String className, String uri) throws Exception;
+
   public Path getModelPath() {
     return Paths.get(TrainDBConfiguration.getTrainDBPrefixPath(), "models",
         modeltypeName, modelName);

--- a/traindb-core/src/main/java/traindb/engine/TrainDBFileModelRunner.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBFileModelRunner.java
@@ -126,4 +126,26 @@ public class TrainDBFileModelRunner extends AbstractTrainDBModelRunner {
     return outputPath;
   }
 
+  @Override
+  public String listHyperparameters(String className, String uri) throws Exception {
+
+    Path modelPath = getModelPath();
+    Files.createDirectories(modelPath);
+    String outputPath = modelPath.toString() + "/hyperparams.json";
+
+    ProcessBuilder pb = new ProcessBuilder("python", getModelRunnerPath(), "list",
+        className, TrainDBConfiguration.absoluteUri(uri), outputPath);
+    pb.inheritIO();
+    Process process = pb.start();
+    process.waitFor();
+
+    if (process.exitValue() != 0) {
+      throw new TrainDBException("failed to train model");
+    }
+
+    String hyperparamsInfo =
+        new String(Files.readAllBytes(Paths.get(outputPath)), StandardCharsets.UTF_8);
+    return hyperparamsInfo;
+  }
+
 }

--- a/traindb-core/src/main/java/traindb/engine/TrainDBPy4JModelRunner.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBPy4JModelRunner.java
@@ -132,6 +132,11 @@ public class TrainDBPy4JModelRunner extends AbstractTrainDBModelRunner {
     throw new TrainDBException("Not supported yet in Py4J model runner");
   }
 
+  @Override
+  public String listHyperparameters(String className, String uri) throws Exception {
+    return null; // TODO
+  }
+
   private int getAvailablePort() throws Exception {
     ServerSocket s;
     try {

--- a/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.calcite.sql.SqlDialect;
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import traindb.adapter.TrainDBSqlDialect;
@@ -478,6 +480,36 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
   }
 
   @Override
+  public TrainDBListResultSet showHyperparameters(Map<String, Object> filterPatterns)
+      throws Exception {
+    List<String> header = Arrays.asList("modeltype_name", "hyperparameter_name", "value_type",
+        "default_value", "description");
+    checkShowWhereColumns(filterPatterns, Arrays.asList("modeltype_name"));
+
+    T_tracer.startTaskTracer("show hyperparameters");
+    T_tracer.openTaskTime("scan : modeltype");
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    List<List<Object>> hyperparamInfo = new ArrayList<>();
+    for (MModeltype mModeltype : catalogContext.getModeltypes(filterPatterns)) {
+      if (mModeltype.getHyperparameters().equals("null")) {
+        continue;
+      }
+      List<Hyperparameter> hyperparameterList = Arrays.asList(
+          objectMapper.readValue(mModeltype.getHyperparameters(), Hyperparameter[].class));
+      for (Hyperparameter hyperparam : hyperparameterList) {
+        hyperparamInfo.add(Arrays.asList(mModeltype.getModeltypeName(), hyperparam.getName(),
+            hyperparam.getType(), hyperparam.getDefaultValue(), hyperparam.getDescription()));
+      }
+    }
+
+    T_tracer.closeTaskTime("SUCCESS");
+    T_tracer.endTaskTracer();
+
+    return new TrainDBListResultSet(header, hyperparamInfo);
+  }
+
+  @Override
   public void useSchema(String schemaName) throws Exception {
     T_tracer.startTaskTracer("use " + schemaName);
     T_tracer.openTaskTime("use schema");
@@ -593,7 +625,8 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
       throws TrainDBException {
     for (String key : patterns.keySet()) {
       if (!columns.contains(key)) {
-        throw new TrainDBException("column '" + key + "' does not exist");
+        throw new TrainDBException("column '" + key + "' does not exist. "
+            + "Only " + String.join(",", columns) + " can be specified.");
       }
     }
   }
@@ -604,6 +637,30 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
       if (columns.contains(key)) {
         patterns.put(prefix + "." + key, patterns.remove(key));
       }
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class Hyperparameter {
+    private String name;
+    private String type;
+    private String defaultValue;
+    private String description;
+
+    public String getName() {
+      return name;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public String getDefaultValue() {
+      return defaultValue;
+    }
+
+    public String getDescription() {
+      return description;
     }
   }
 }

--- a/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
@@ -76,7 +76,9 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
     T_tracer.closeTaskTime("SUCCESS");
 
     T_tracer.openTaskTime("create modeltype");
-    catalogContext.createModeltype(name, category, location, className, uri);
+    AbstractTrainDBModelRunner runner = createModelRunner(name, "");
+    String hyperparamsInfo = runner.listHyperparameters(className, uri);
+    catalogContext.createModeltype(name, category, location, className, uri, hyperparamsInfo);
     T_tracer.closeTaskTime("SUCCESS");
 
     T_tracer.endTaskTracer();

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
@@ -104,6 +104,9 @@ public final class TrainDBSql {
       case SHOW_TABLES:
         TrainDBSqlShowCommand showTables = (TrainDBSqlShowCommand) command;
         return runner.showTables(showTables.getWhereExpressionMap());
+      case SHOW_HYPERPARAMETERS:
+        TrainDBSqlShowCommand showHyperparams = (TrainDBSqlShowCommand) command;
+        return runner.showHyperparameters(showHyperparams.getWhereExpressionMap());
       case USE_SCHEMA:
         TrainDBSqlUseSchema useSchema = (TrainDBSqlUseSchema) command;
         runner.useSchema(useSchema.getSchemaName());
@@ -197,6 +200,8 @@ public final class TrainDBSql {
         commands.add(new TrainDBSqlShowCommand.Schemas(whereExprMap));
       } else if (showTarget.equals("TABLES")) {
         commands.add(new TrainDBSqlShowCommand.Tables(whereExprMap));
+      } else if (showTarget.equals("HYPERPARAMETERS")) {
+        commands.add(new TrainDBSqlShowCommand.Hyperparameters(whereExprMap));
       } else if (showTarget.equals("QUERYLOGS")) {
         commands.add(new TrainDBSqlShowCommand.QueryLogs(whereExprMap));
       } else if (showTarget.equals("TASKS")) {

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSqlCommand.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSqlCommand.java
@@ -29,6 +29,7 @@ public abstract class TrainDBSqlCommand {
     SHOW_SYNOPSES,
     SHOW_SCHEMAS,
     SHOW_TABLES,
+    SHOW_HYPERPARAMETERS,
     USE_SCHEMA,
     DESCRIBE_TABLE,
     BYPASS_DDL_STMT,

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSqlRunner.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSqlRunner.java
@@ -44,6 +44,8 @@ public interface TrainDBSqlRunner {
 
   TrainDBListResultSet showTables(Map<String, Object> filterPatterns) throws Exception;
 
+  TrainDBListResultSet showHyperparameters(Map<String, Object> filterPatterns) throws Exception;
+
   void useSchema(String schemaName) throws Exception;
 
   TrainDBListResultSet describeTable(String schemaName, String tableName) throws Exception;

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSqlShowCommand.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSqlShowCommand.java
@@ -83,6 +83,17 @@ abstract class TrainDBSqlShowCommand extends TrainDBSqlCommand {
     }
   }
 
+  static class Hyperparameters extends TrainDBSqlShowCommand {
+    Hyperparameters(Map<String, Object> whereExprMap) {
+      super(whereExprMap);
+    }
+
+    @Override
+    public Type getType() {
+      return Type.SHOW_HYPERPARAMETERS;
+    }
+  }
+
   static class QueryLogs extends TrainDBSqlShowCommand {
     QueryLogs(Map<String, Object> whereExprMap) {
       super(whereExprMap);

--- a/traindb-core/src/test/resources/models/TableGAN.py
+++ b/traindb-core/src/test/resources/models/TableGAN.py
@@ -16,7 +16,7 @@ import logging
 import rdt
 from sdgym.synthesizers import TableGAN as SDGymTableGAN
 from sdgym.errors import UnsupportedDataset
-from TrainDBBaseModel import TrainDBSynopsisModel
+from TrainDBBaseModel import TrainDBModel, TrainDBSynopsisModel
 import pandas as pd
 
 import torch
@@ -30,7 +30,7 @@ class TableGAN(TrainDBSynopsisModel, SDGymTableGAN):
                  num_channels=64,
                  l2scale=1e-5,
                  batch_size=500,
-                 epochs=1):
+                 epochs=300):
  
         self.ht = rdt.HyperTransformer(default_data_type_transformers={
             'categorical': 'LabelEncodingTransformer',
@@ -75,6 +75,15 @@ class TableGAN(TrainDBSynopsisModel, SDGymTableGAN):
         self.transformer = saved_model['transformer']
         self.generator = saved_model['generator']
         self.columns = saved_model['columns']
+
+    def list_hyperparameters():
+        hparams = []
+        hparams.append(TrainDBModel.createHyperparameter('random_dim', 'int', '100', 'the size of the random sample passed to the generator'))
+        hparams.append(TrainDBModel.createHyperparameter('num_channels', 'int', '64', 'the number of channels'))
+        hparams.append(TrainDBModel.createHyperparameter('l2scale', 'float', '1e-5', 'regularization term'))
+        hparams.append(TrainDBModel.createHyperparameter('batch_size', 'int', '500', 'the number of samples to process in each step'))
+        hparams.append(TrainDBModel.createHyperparameter('epochs', 'int', '300', 'the number of training epochs'))
+        return hparams
 
     def synopsis(self, row_count):
         LOGGER.info("Synopsis Generating %s", self.__class__.__name__)

--- a/traindb-core/src/test/resources/models/TrainDBBaseModel.py
+++ b/traindb-core/src/test/resources/models/TrainDBBaseModel.py
@@ -13,9 +13,13 @@
 """
 
 import abc
+import collections
 
 class TrainDBModel(abc.ABC):
   """Base class for all the ``TrainDB`` models."""
+
+  Hyperparameter = collections.namedtuple("Hyperparameter", "name type defaultValue description")
+
   def get_columns(self, real_data, table_metadata):
     model_columns = []
     categorical_columns = []
@@ -36,6 +40,9 @@ class TrainDBModel(abc.ABC):
 
     return model_columns, categorical_columns
 
+  def createHyperparameter(name, datatype, default_value, comment):
+    return TrainDBModel.Hyperparameter(name, datatype, default_value, comment)._asdict()
+
   def train(self, real_data, table_metadata): 
     pass
 
@@ -45,9 +52,17 @@ class TrainDBModel(abc.ABC):
   def load(self, input_path):
     pass
 
+  def list_hyperparameters():
+    pass
 
 class TrainDBSynopsisModel(TrainDBModel, abc.ABC):
   """Base class for all the ``TrainDB`` synopsis generation models."""
 
   def synopsis(self, row_count):
+    pass
+
+class TrainDBInferenceModel(TrainDBModel, abc.ABC):
+  """Base class for all the ``TrainDB`` inference models."""
+
+  def infer(self, agg_expr, group_by_column, where_condition):
     pass

--- a/traindb-core/src/test/resources/sql/synopsis.iq
+++ b/traindb-core/src/test/resources/sql/synopsis.iq
@@ -18,6 +18,20 @@ SHOW MODELTYPES;
 
 !ok
 
+SHOW HYPERPARAMETERS WHERE modeltype_name = 'tablegan';
++----------------+---------------------+------------+---------------+-------------------------------------------------------+
+| modeltype_name | hyperparameter_name | value_type | default_value | description                                           |
++----------------+---------------------+------------+---------------+-------------------------------------------------------+
+| tablegan       | random_dim          | int        | 100           | the size of the random sample passed to the generator |
+| tablegan       | num_channels        | int        | 64            | the number of channels                                |
+| tablegan       | l2scale             | float      | 1e-5          | regularization term                                   |
+| tablegan       | batch_size          | int        | 500           | the number of samples to process in each step         |
+| tablegan       | epochs              | int        | 300           | the number of training epochs                         |
++----------------+---------------------+------------+---------------+-------------------------------------------------------+
+(5 rows)
+
+!ok
+
 CREATE MODELTYPE tablegan FOR SYNOPSIS AS LOCAL CLASS 'TableGAN' IN 'models/TableGAN.py';
 
 modeltype 'tablegan' already exists


### PR DESCRIPTION
The ```SHOW HYPERPARAMETERS``` command has been implemented.
You can see the hyperparameters as follows:
```sql
SHOW HYPERPARAMETERS WHERE modeltype_name = 'tablegan';
SHOW HYPERPARAMETERS WHERE modeltype_name LIKE '%gan%';
```