### PR TITLE
Feat: Train models on remote model servers

### DIFF
--- a/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
@@ -26,6 +26,7 @@ import traindb.catalog.pm.MSchema;
 import traindb.catalog.pm.MSynopsis;
 import traindb.catalog.pm.MTable;
 import traindb.catalog.pm.MTask;
+import traindb.catalog.pm.MTrainingStatus;
 
 public interface CatalogContext {
 
@@ -61,6 +62,11 @@ public interface CatalogContext {
   boolean modelExists(String name);
 
   MModel getModel(String name);
+
+  Collection<MTrainingStatus> getTrainingStatus(Map<String, Object> filterPatterns)
+      throws CatalogException;
+
+  void updateTrainingStatus(String modelName, String status) throws CatalogException;
 
   /* Synopsis */
   MSynopsis createSynopsis(String synopsisName, String modelName, Integer rows, Double ratio)

--- a/traindb-catalog/src/main/java/traindb/catalog/pm/MModel.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/pm/MModel.java
@@ -14,6 +14,8 @@
 
 package traindb.catalog.pm;
 
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.IdGeneratorStrategy;
@@ -57,6 +59,9 @@ public final class MModel {
 
   @Persistent
   private byte[] model_options;
+
+  @Persistent(mappedBy = "model", dependentElement = "true")
+  private Collection<MTrainingStatus> training_status;
 
   public MModel(
       MModeltype modeltype, String modelName, String schemaName, String tableName,
@@ -102,5 +107,18 @@ public final class MModel {
 
   public String getModelOptions() {
     return new String(model_options);
+  }
+
+  public Collection<MTrainingStatus> trainingStatus() {
+    return training_status;
+  }
+
+  public boolean isEnabled() {
+    if (training_status.isEmpty() || training_status.size() == 0) {
+      return true;
+    }
+    Comparator<MTrainingStatus> comparator = Comparator.comparing(MTrainingStatus::getStartTime);
+    MTrainingStatus latestStatus = training_status.stream().max(comparator).get();
+    return latestStatus.getTrainingStatus().equals("FINISHED");
   }
 }

--- a/traindb-catalog/src/main/java/traindb/catalog/pm/MTrainingStatus.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/pm/MTrainingStatus.java
@@ -52,6 +52,10 @@ public final class MTrainingStatus {
     this.model = model;
   }
 
+  public String getModelName() {
+    return model_name;
+  }
+
   public Timestamp getStartTime() {
     return start_time;
   }

--- a/traindb-catalog/src/main/java/traindb/catalog/pm/MTrainingStatus.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/pm/MTrainingStatus.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.catalog.pm;
+
+import java.sql.Timestamp;
+import javax.jdo.annotations.Column;
+import javax.jdo.annotations.IdGeneratorStrategy;
+import javax.jdo.annotations.Index;
+import javax.jdo.annotations.PersistenceCapable;
+import javax.jdo.annotations.Persistent;
+import javax.jdo.annotations.PrimaryKey;
+import traindb.catalog.CatalogConstants;
+
+@PersistenceCapable
+@Index(name="TRAINING_STATUS_IDX", members={"model_name", "start_time"})
+public final class MTrainingStatus {
+  @PrimaryKey
+  @Persistent(valueStrategy = IdGeneratorStrategy.INCREMENT)
+  private long id;
+
+  @Persistent
+  @Column(length = CatalogConstants.IDENTIFIER_MAX_LENGTH)
+  private String model_name;
+
+  @Persistent
+  private Timestamp start_time;
+
+  @Persistent
+  @Column(length = 9)
+  // Status: TRAINING, FINISHED
+  private String training_status;
+
+  @Persistent(dependent = "false")
+  private MModel model;
+
+  public MTrainingStatus(String modelName, String status, Timestamp startTime, MModel model) {
+    this.model_name = modelName;
+    this.training_status = status;
+    this.start_time = startTime;
+    this.model = model;
+  }
+
+  public Timestamp getStartTime() {
+    return start_time;
+  }
+
+  public String getTrainingStatus() {
+    return training_status;
+  }
+
+  public MModel getModel() {
+    return model;
+  }
+
+  public void setTrainingStatus(String status) {
+    this.training_status = status;
+  }
+}

--- a/traindb-core/src/main/antlr4/traindb/sql/TrainDBSql.g4
+++ b/traindb-core/src/main/antlr4/traindb/sql/TrainDBSql.g4
@@ -125,6 +125,7 @@ showTargets
     | K_SCHEMAS
     | K_TABLES
     | K_HYPERPARAMETERS
+    | K_TRAININGS
     | K_QUERYLOGS
     | K_TASKS
     ;
@@ -241,6 +242,7 @@ K_SYNOPSIS : S Y N O P S I S ;
 K_TABLES : T A B L E S ;
 K_TASKS : T A S K S ;
 K_TRAIN : T R A I N ;
+K_TRAININGS : T R A I N I N G S;
 K_USE : U S E ;
 K_WHERE : W H E R E ;
 

--- a/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
+++ b/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
@@ -53,6 +53,10 @@ public abstract class AbstractTrainDBModelRunner {
 
   public abstract String listHyperparameters(String className, String uri) throws Exception;
 
+  public boolean checkAvailable(String modelName) throws Exception {
+    return true;
+  }
+
   public Path getModelPath() {
     return Paths.get(TrainDBConfiguration.getTrainDBPrefixPath(), "models",
         modeltypeName, modelName);

--- a/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
+++ b/traindb-core/src/main/java/traindb/engine/AbstractTrainDBModelRunner.java
@@ -58,6 +58,21 @@ public abstract class AbstractTrainDBModelRunner {
         modeltypeName, modelName);
   }
 
+  public static AbstractTrainDBModelRunner createModelRunner(
+      TrainDBConnectionImpl conn, CatalogContext catalogContext, TrainDBConfiguration config,
+      String modeltypeName, String modelName, String location) {
+    if (location.equals("REMOTE")) {
+      return new TrainDBFastApiModelRunner(conn, catalogContext, modeltypeName, modelName);
+    }
+    // location.equals("LOCAL")
+    if (config.getModelRunner().equals("py4j")) {
+      return new TrainDBPy4JModelRunner(conn, catalogContext, modeltypeName, modelName);
+    }
+
+    return new TrainDBFileModelRunner(conn, catalogContext, modeltypeName, modelName);
+  }
+
+
   protected String buildSelectTrainingDataQuery(String schemaName, String tableName,
                                                 List<String> columnNames) {
     StringBuilder sb = new StringBuilder();

--- a/traindb-core/src/main/java/traindb/engine/TrainDBFastApiModelRunner.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBFastApiModelRunner.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.engine;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.text.StringEscapeUtils;
+import org.json.simple.JSONObject;
+import traindb.catalog.CatalogContext;
+import traindb.catalog.pm.MModeltype;
+import traindb.common.TrainDBException;
+import traindb.jdbc.TrainDBConnectionImpl;
+import traindb.schema.TrainDBTable;
+
+public class TrainDBFastApiModelRunner extends AbstractTrainDBModelRunner {
+
+  private static final String BOUNDARY = "*****";
+  private static final String DOUBLE_HYPHEN = "--";
+  private static final String CRLF = "\r\n";
+
+  public TrainDBFastApiModelRunner(
+      TrainDBConnectionImpl conn, CatalogContext catalogContext, String modeltypeName,
+      String modelName) {
+    super(conn, catalogContext, modeltypeName, modelName);
+  }
+
+  private static String checkTrailingSlash(String uri) {
+    return uri.endsWith("/") ? uri : uri + "/";
+  }
+
+  private void addString(DataOutputStream request, String key, String value) throws Exception {
+    StringBuilder sb = new StringBuilder();
+    sb.append(DOUBLE_HYPHEN).append(BOUNDARY).append(CRLF);
+    sb.append("Content-Disposition: form-data; name=\""+ key +"\"").append(CRLF);
+    sb.append("Content-Type: plain/text").append(CRLF);
+    sb.append(CRLF).append(value).append(CRLF);
+    request.writeBytes(sb.toString());
+  }
+
+  private void addMetadataFile(DataOutputStream request, JSONObject metadata) throws Exception {
+    StringBuilder sb = new StringBuilder();
+    sb.append(DOUBLE_HYPHEN).append(BOUNDARY).append(CRLF);
+    sb.append("Content-Disposition: form-data; ");
+    sb.append("name=\"metadata_file\"; filename=\"metadata.json\"").append(CRLF);
+    sb.append("Content-Type: application/json").append(CRLF);
+    sb.append(CRLF).append(metadata.toJSONString()).append(CRLF);
+    request.writeBytes(sb.toString());
+  }
+
+  private void finishMultipartRequest(DataOutputStream request) throws Exception {
+    request.writeBytes(DOUBLE_HYPHEN + BOUNDARY + DOUBLE_HYPHEN + CRLF);
+    request.flush();
+    request.close();
+  }
+
+  @Override
+  public void trainModel(TrainDBTable table, List<String> columnNames,
+                         Map<String, Object> trainOptions, JavaTypeFactory typeFactory)
+      throws Exception {
+    MModeltype mModeltype = catalogContext.getModeltype(modeltypeName);
+    URL url = new URL(checkTrailingSlash(mModeltype.getUri())
+        + "modeltype/" + mModeltype.getClassName() + "/train");
+    HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+    httpConn.setRequestMethod("POST");
+    httpConn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + BOUNDARY);
+    httpConn.setDoOutput(true);
+
+    BasicDataSource ds = conn.getDataSource();
+    String schemaName = table.getSchema().getName();
+    String tableName = table.getName();
+    String sql = buildSelectTrainingDataQuery(schemaName, tableName, columnNames);
+
+    JSONObject tableMetadata = buildTableMetadata(schemaName, tableName, columnNames, trainOptions,
+        table.getRowType(typeFactory));
+
+    OutputStream outputStream = httpConn.getOutputStream();
+    DataOutputStream request = new DataOutputStream(outputStream);
+
+    addString(request, "modeltype_class", mModeltype.getClassName());
+    addString(request, "model_name", modelName);
+    addString(request, "jdbc_driver_class", ds.getDriverClassName());
+    addString(request, "db_url", ds.getUrl());
+    addString(request, "db_user", ds.getUsername());
+    addString(request, "db_pwd", ds.getPassword());
+    addString(request, "select_training_data_sql", sql);
+    addMetadataFile(request, tableMetadata);
+    finishMultipartRequest(request);
+
+    if (httpConn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new TrainDBException("failed to train model");
+    }
+
+    StringBuilder response = new StringBuilder();
+    try (BufferedReader reader = new BufferedReader(
+        new InputStreamReader(httpConn.getInputStream(), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        response.append(line);
+      }
+    }
+    System.out.println(response);
+  }
+
+  @Override
+  public void generateSynopsis(String outputPath, int rows) throws Exception {
+    MModeltype mModeltype = catalogContext.getModel(modelName).getModeltype();
+    URL url = new URL(checkTrailingSlash(mModeltype.getUri()) + "model/" + modelName + "/synopsis");
+
+    HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+    httpConn.setRequestMethod("POST");
+    httpConn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + BOUNDARY);
+    httpConn.setDoOutput(true);
+
+    OutputStream outputStream = httpConn.getOutputStream();
+    DataOutputStream request = new DataOutputStream(outputStream);
+
+    addString(request, "model_name", modelName);
+    addString(request, "modeltype_class", mModeltype.getClassName());
+    addString(request, "rows", String.valueOf(rows));
+    finishMultipartRequest(request);
+
+    if (httpConn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new TrainDBException("failed to create synopsis");
+    }
+
+    Files.createDirectories(Paths.get(outputPath).getParent());
+    FileOutputStream fos = new FileOutputStream(outputPath);
+    InputStream is = httpConn.getInputStream();
+    int read;
+    byte[] buf = new byte[32768];
+    while ((read = is.read(buf)) > 0) {
+      fos.write(buf, 0, read);
+    }
+    fos.close();
+    is.close();
+  }
+
+  @Override
+  public String infer(String aggregateExpression, String groupByColumn, String whereCondition)
+      throws Exception {
+    MModeltype mModeltype = catalogContext.getModel(modelName).getModeltype();
+    URL url = new URL(checkTrailingSlash(mModeltype.getUri()) + "model/" + modelName + "/infer");
+
+    HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+    httpConn.setRequestMethod("POST");
+    httpConn.setRequestProperty("Content-Type", "multipart/form-data; boundary=" + BOUNDARY);
+    httpConn.setDoOutput(true);
+
+    OutputStream outputStream = httpConn.getOutputStream();
+    DataOutputStream request = new DataOutputStream(outputStream);
+
+    addString(request, "model_name", modelName);
+    addString(request, "modeltype_class", mModeltype.getClassName());
+    addString(request, "agg_expr", aggregateExpression);
+    addString(request, "group_by_column", groupByColumn);
+    addString(request, "where_condition", whereCondition);
+    finishMultipartRequest(request);
+
+    if (httpConn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new TrainDBException("failed to infer '" + aggregateExpression + "'");
+    }
+
+    String modelPath = getModelPath().toString();
+    UUID queryId = UUID.randomUUID();
+    String outputPath = modelPath + "/infer" + queryId + ".csv";
+
+    Files.createDirectories(Paths.get(outputPath).getParent());
+    FileOutputStream fos = new FileOutputStream(outputPath);
+    InputStream is = httpConn.getInputStream();
+    int read;
+    byte[] buf = new byte[32768];
+    while ((read = is.read(buf)) > 0) {
+      fos.write(buf, 0, read);
+    }
+    fos.close();
+    is.close();
+
+    return outputPath;
+  }
+
+  @Override
+  public String listHyperparameters(String className, String uri) throws Exception {
+    URL url = new URL(checkTrailingSlash(uri) + "modeltype/" + className + "/hyperparams");
+    HttpURLConnection httpConn = (HttpURLConnection) url.openConnection();
+    httpConn.setRequestMethod("GET");
+
+    if (httpConn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      throw new TrainDBException("failed to list hyperparameters");
+    }
+
+    StringBuilder response = new StringBuilder();
+    BufferedReader reader = new BufferedReader(
+        new InputStreamReader(httpConn.getInputStream(), StandardCharsets.UTF_8));
+    String line;
+    while ((line = reader.readLine()) != null) {
+      response.append(line);
+    }
+
+    // remove beginning/ending double quotes and unescape
+    return StringEscapeUtils.unescapeJava(response.toString().replaceAll("^\"|\"$", ""));
+  }
+
+}

--- a/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
@@ -312,6 +312,14 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
 
     AbstractTrainDBModelRunner runner = createModelRunner(
         mModeltype.getModeltypeName(), modelName, mModeltype.getLocation());
+
+    if (!mModel.isEnabled()) {  // remote model
+      if (!runner.checkAvailable(modelName)) {
+        throw new TrainDBException(
+            "model '" + modelName + "' is not available (training is not finished)");
+      }
+      catalogContext.updateTrainingStatus(modelName, "FINISHED");
+    }
     String outputPath = runner.getModelPath().toString() + '/' + synopsisName + ".csv";
     runner.generateSynopsis(outputPath, limitNumber);
     T_tracer.closeTaskTime("SUCCESS");

--- a/traindb-core/src/main/java/traindb/planner/TrainDBPlanner.java
+++ b/traindb-core/src/main/java/traindb/planner/TrainDBPlanner.java
@@ -93,6 +93,10 @@ public class TrainDBPlanner extends VolcanoPlanner {
     Hook.PLANNER.run(this); // allow test to add or remove rules
   }
 
+  public TrainDBConfiguration getConfig() {
+    return (TrainDBConfiguration) catalogReader.getConfig();
+  }
+
   private CaqpExecutionTimePolicy createCaqpExecutionTimePolicy(CalciteConnectionConfig config)
       throws Exception {
     CaqpExecutionTimePolicyType policy;

--- a/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateInferenceRule.java
+++ b/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateInferenceRule.java
@@ -42,7 +42,6 @@ import traindb.adapter.python.PythonMLAggregateModelScan;
 import traindb.adapter.python.PythonRel;
 import traindb.catalog.pm.MModel;
 import traindb.engine.AbstractTrainDBModelRunner;
-import traindb.engine.TrainDBFileModelRunner;
 import traindb.planner.TrainDBPlanner;
 
 @Value.Enclosing
@@ -116,11 +115,10 @@ public class ApproxAggregateInferenceRule
 
     // TODO choose the best inference model
     final MModel bestInferenceModel = candidateModels.iterator().next();
-
-    AbstractTrainDBModelRunner runner =
-        new TrainDBFileModelRunner(null, planner.getCatalogContext(),
-            bestInferenceModel.getModeltype().getModeltypeName(),
-            bestInferenceModel.getModelName());
+    AbstractTrainDBModelRunner runner = AbstractTrainDBModelRunner.createModelRunner(
+        null, planner.getCatalogContext(), planner.getConfig(),
+        bestInferenceModel.getModeltype().getModeltypeName(),
+        bestInferenceModel.getModelName(), bestInferenceModel.getModeltype().getLocation());
 
     PythonMLAggregateModel modelTable = new PythonMLAggregateModel(runner,
         aggregate.getAggCallList(), aggregate.getGroupSet(), aggregate.getInput().getRowType(),

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
@@ -107,6 +107,9 @@ public final class TrainDBSql {
       case SHOW_HYPERPARAMETERS:
         TrainDBSqlShowCommand showHyperparams = (TrainDBSqlShowCommand) command;
         return runner.showHyperparameters(showHyperparams.getWhereExpressionMap());
+      case SHOW_TRAININGS:
+        TrainDBSqlShowCommand showTrainings = (TrainDBSqlShowCommand) command;
+        return runner.showTrainings(showTrainings.getWhereExpressionMap());
       case USE_SCHEMA:
         TrainDBSqlUseSchema useSchema = (TrainDBSqlUseSchema) command;
         runner.useSchema(useSchema.getSchemaName());
@@ -202,6 +205,8 @@ public final class TrainDBSql {
         commands.add(new TrainDBSqlShowCommand.Tables(whereExprMap));
       } else if (showTarget.equals("HYPERPARAMETERS")) {
         commands.add(new TrainDBSqlShowCommand.Hyperparameters(whereExprMap));
+      } else if (showTarget.equals("TRAININGS")) {
+        commands.add(new TrainDBSqlShowCommand.Trainings(whereExprMap));
       } else if (showTarget.equals("QUERYLOGS")) {
         commands.add(new TrainDBSqlShowCommand.QueryLogs(whereExprMap));
       } else if (showTarget.equals("TASKS")) {

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSqlCommand.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSqlCommand.java
@@ -22,6 +22,7 @@ public abstract class TrainDBSqlCommand {
     DROP_MODELTYPE,
     SHOW_MODELTYPES,
     SHOW_MODELS,
+    SHOW_TRAININGS,
     TRAIN_MODEL,
     DROP_MODEL,
     CREATE_SYNOPSIS,

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSqlRunner.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSqlRunner.java
@@ -46,6 +46,8 @@ public interface TrainDBSqlRunner {
 
   TrainDBListResultSet showHyperparameters(Map<String, Object> filterPatterns) throws Exception;
 
+  TrainDBListResultSet showTrainings(Map<String, Object> filterPatterns) throws Exception;
+
   void useSchema(String schemaName) throws Exception;
 
   TrainDBListResultSet describeTable(String schemaName, String tableName) throws Exception;

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSqlShowCommand.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSqlShowCommand.java
@@ -94,6 +94,17 @@ abstract class TrainDBSqlShowCommand extends TrainDBSqlCommand {
     }
   }
 
+  static class Trainings extends TrainDBSqlShowCommand {
+    Trainings(Map<String, Object> whereExprMap) {
+      super(whereExprMap);
+    }
+
+    @Override
+    public Type getType() {
+      return Type.SHOW_TRAININGS;
+    }
+  }
+
   static class QueryLogs extends TrainDBSqlShowCommand {
     QueryLogs(Map<String, Object> whereExprMap) {
       super(whereExprMap);


### PR DESCRIPTION
A simple model server are implemented.
You can train a model in a remote server as follows.

1. Run ```TrainDBModelServer.py``` in ```$TRAINDB_PREFIX/models```
2. Create a modeltype using ```REMOTE``` keyword. For example,
```sql
CREATE MODELTYPE tablegan FOR SYNOPSIS AS REMOTE CLASS 'TableGAN' IN 'http://localhost:58080/';
CREATE MODELTYPE rspn FOR INFERENCE AS REMOTE CLASS 'RSPN' IN 'http://localhost:58080/';
```
For debugging and testing, ```http``` is used here. ```https``` can also be used.
3. Train a model in the same way as the local model.
The difference is that the model is trained asynchronously.
```sql
TRAIN MODEL tgan MODELTYPE tablegan ON instacart.order_products(reordered, add_to_cart_order) OPTIONS ( 'epochs'=1 );
TRAIN MODEL rspn_model MODELTYPE rspn ON instacart.order_products(reordered, add_to_cart_order);
```
4. You can check the training status using the following commands.
```sql
SHOW TRAININGS;
SHOW TRAININGS where 'model_name' = 'tgan'
SHOW TRAININGS where 'model_server' LIKE '%localhost%';
SHOW TRAININGS where 'status' = 'TRAINING';
```
5. training status will be updated when running some commands:
```SHOW TRAININGS```, ```CREATE SYNOPSIS```, ```SELECT APPROXIMATE```