### PR TITLE
Feat: TRAIN MODEL on columns from multiple tables

### DIFF
--- a/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
@@ -142,6 +142,13 @@ public interface CatalogContext {
 
   void deleteTasks(Integer cnt) throws CatalogException;
 
+  /* Join */
+  public MTable createJoinTable(List<String> schemaNames, List<String> tableNames,
+                                List<List<String>> columnNames, List<RelDataType> dataTypes,
+                                String joinQuery) throws CatalogException;
+
+  public void dropJoinTable(String schemaName, String joinTableName) throws CatalogException;
+
   /* Common */
   void close();
 }

--- a/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
@@ -143,11 +143,12 @@ public interface CatalogContext {
   void deleteTasks(Integer cnt) throws CatalogException;
 
   /* Join */
-  public MTable createJoinTable(List<String> schemaNames, List<String> tableNames,
-                                List<List<String>> columnNames, List<RelDataType> dataTypes,
-                                String joinQuery) throws CatalogException;
+  MTable createJoinTable(List<String> schemaNames, List<String> tableNames,
+                         List<List<String>> columnNames, List<RelDataType> dataTypes,
+                         String joinCondition) throws CatalogException;
 
-  public void dropJoinTable(String schemaName, String joinTableName) throws CatalogException;
+  void dropJoinTable(String schemaName, String joinTableName) throws CatalogException;
+
 
   /* Common */
   void close();

--- a/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/CatalogContext.java
@@ -149,6 +149,9 @@ public interface CatalogContext {
 
   void dropJoinTable(String schemaName, String joinTableName) throws CatalogException;
 
+  Collection<MSynopsis> getJoinSynopses(
+      List<Long> baseTableIds, Map<Long, List<String>> columnNames, String joinCondition)
+      throws CatalogException;
 
   /* Common */
   void close();

--- a/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/JDOCatalogContext.java
@@ -19,8 +19,11 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
@@ -154,7 +157,7 @@ public final class JDOCatalogContext implements CatalogContext {
   @Override
   public MTable createJoinTable(List<String> schemaNames, List<String> tableNames,
                                 List<List<String>> columnNames, List<RelDataType> dataTypes,
-                                String joinQuery) throws CatalogException {
+                                String joinCondition) throws CatalogException {
     List<Long> srcTableIds = new ArrayList<>();
     for (int i = 0; i < tableNames.size(); i++) {
       MTable table = addTable(schemaNames.get(i), tableNames.get(i), columnNames.get(i),
@@ -168,7 +171,7 @@ public final class JDOCatalogContext implements CatalogContext {
       // use first table's schema as join table's schema
       MTable joinTable =  new MTable(joinTableName, "JOIN", getSchema(schemaNames.get(0)));
       pm.makePersistent(joinTable);
-      MTableExt joinTableExt = new MTableExt(joinTableName, "JOIN", joinQuery, joinTable);
+      MTableExt joinTableExt = new MTableExt(joinTableName, "JOIN", joinCondition, joinTable);
       pm.makePersistent(joinTableExt);
 
       for (int i = 0; i < tableNames.size(); i++) {
@@ -235,6 +238,15 @@ public final class JDOCatalogContext implements CatalogContext {
       mTable = addTable(schemaName, tableName, columnNames, dataType, "TABLE");
     }
     try {
+
+      Set<String> columnNameSet = new HashSet<>();
+      Iterator<String> iter = columnNames.iterator();
+      while (iter.hasNext()) {
+        String colname = iter.next();
+        if (!columnNameSet.add(colname)) {
+          iter.remove();
+        }
+      }
       MModeltype mModeltype = getModeltype(modeltypeName);
       MModel mModel = new MModel(
           mModeltype, modelName, schemaName, tableName, columnNames,

--- a/traindb-catalog/src/main/java/traindb/catalog/pm/MJoin.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/pm/MJoin.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package traindb.catalog.pm;
+
+import java.util.List;
+import javax.jdo.annotations.PersistenceCapable;
+import javax.jdo.annotations.Persistent;
+
+@PersistenceCapable
+public final class MJoin {
+
+  @Persistent
+  private long join_table_id;
+
+  @Persistent
+  private long src_table_id;
+
+  @Persistent
+  private List<String> columns;
+
+  public MJoin(long joinTableId, long srcTableId, List<String> columns) {
+    this.join_table_id = joinTableId;
+    this.src_table_id = srcTableId;
+    this.columns = columns;
+  }
+
+  public List<String> getColumnNames() {
+    return columns;
+  }
+
+}

--- a/traindb-catalog/src/main/java/traindb/catalog/pm/MJoin.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/pm/MJoin.java
@@ -36,8 +36,16 @@ public final class MJoin {
     this.columns = columns;
   }
 
+  public long getJoinTableId() {
+    return join_table_id;
+  }
+
   public List<String> getColumnNames() {
     return columns;
+  }
+
+  public boolean containsColumnNames(List<String> columnNames) {
+    return this.columns.containsAll(columnNames);
   }
 
 }

--- a/traindb-catalog/src/main/java/traindb/catalog/pm/MTable.java
+++ b/traindb-catalog/src/main/java/traindb/catalog/pm/MTable.java
@@ -56,6 +56,10 @@ public final class MTable {
     this.schema = schema;
   }
 
+  public long getId() {
+    return id;
+  }
+
   public String getTableName() {
     return table_name;
   }

--- a/traindb-core/src/main/antlr4/traindb/sql/TrainDBSql.g4
+++ b/traindb-core/src/main/antlr4/traindb/sql/TrainDBSql.g4
@@ -61,7 +61,8 @@ dropModeltype
     ;
 
 trainModel
-    : K_TRAIN K_MODEL modelName K_MODELTYPE modeltypeName K_ON tableName '(' columnNameList ')'
+    : K_TRAIN K_MODEL modelName K_MODELTYPE modeltypeName
+      ( K_FROM | K_ON ) tableName '(' columnNameList ')' joinTableListOpt* joinTableConditionListOpt?
       trainSampleClause? trainModelOptionsClause?
     ;
 
@@ -115,6 +116,26 @@ modeltypeClassName
 
 modeltypeUri
     : STRING_LITERAL
+    ;
+
+joinTableListOpt
+    : K_JOIN tableName '(' columnNameList ')'
+    ;
+
+joinTableConditionListOpt
+    : K_ON tableConditionList
+    ;
+
+tableConditionList
+    : tableConditionOr (K_AND tableConditionOr)*
+    ;
+
+tableConditionOr
+    : tableCondtionNot (K_OR tableCondtionNot)*
+    ;
+
+tableCondtionNot
+    : K_NOT? predicate
     ;
 
 trainSampleClause
@@ -315,6 +336,52 @@ ddlString
     : ( . | WHITESPACES )+?
     ;
 
+comparisonOperator
+    : '=' | '>' | '<' | '<' '=' | '>' '=' | '<' '>' | '!' '=' | '!' '>' | '!' '<'
+    ;
+
+predicate
+    : '(' tableConditionList ')'
+    | expression comparisonOperator expression
+    | expression K_NOT? (K_LIKE | K_RLIKE) expression (K_ESCAPE expression)?
+    | expression K_IS nullConstant
+    ;
+
+expression
+    : K_NULL
+    | STRING_LITERAL
+    | NUMERIC_LITERAL
+    | K_TRUE
+    | K_FALSE
+    | fullColumnName
+    | '(' expression ')'
+    | expression op=('*' | '/' | '%') expression
+    | op=('+' | '-') expression
+    | expression op=('+' | '-' | '&' | '^' | '|' | '#' | '||' | '<<' | '>>'  ) expression
+    | expression comparisonOperator expression
+    | K_NOT expression
+    | expression K_IS nullConstant
+    | date
+    ;
+
+fullColumnName
+    : (tableName '.')? columnName
+    ;
+
+nullConstant
+    : K_NOT? K_NULL
+    ;
+
+date
+    : K_DATE constant
+    ;
+
+constant
+    : STRING_LITERAL
+    | BINARY_STRING_LITERAL
+    | NUMERIC_LITERAL
+    ;
+
 error
     : UNEXPECTED_CHAR
         {
@@ -337,7 +404,9 @@ K_DESCRIBE : D E S C R I B E ;
 K_DISABLE : D I S A B L E ;
 K_DROP : D R O P ;
 K_ENABLE : E N A B L E ;
+K_ESCAPE : E S C A P E ;
 K_EXPORT : E X P O R T ;
+K_FALSE : F A L S E ;
 K_FILE : F I L E ;
 K_FOR : F O R ;
 K_FROM : F R O M ;
@@ -346,15 +415,21 @@ K_IMPORT : I M P O R T ;
 K_IN : I N ;
 K_INCREMENTAL : I N C R E M E N T A L ;
 K_INFERENCE : I N F E R E N C E ;
+K_IS : I S ;
+K_JOIN : J O I N ;
 K_LIKE : L I K E ;
+K_RLIKE : R L I K E ;
 K_LIMIT : L I M I T ;
 K_LOCAL : L O C A L ;
 K_MODEL : M O D E L ;
 K_MODELS : M O D E L S ;
 K_MODELTYPE : M O D E L T Y P E ;
 K_MODELTYPES : M O D E L T Y P E S ;
+K_NOT : N O T ;
+K_NULL : N U L L ;
 K_ON : O N ;
 K_OPTIONS : O P T I O N S ;
+K_OR : O R ;
 K_SAMPLE : S A M P L E ;
 K_PERCENT : P E R C E N T ;
 K_PARTITIONS : P A R T I T I O N S ;
@@ -373,6 +448,7 @@ K_TASKS : T A S K S ;
 K_TO : T O ;
 K_TRAIN : T R A I N ;
 K_TRAININGS : T R A I N I N G S;
+K_TRUE : T R U E ;
 K_USE : U S E ;
 K_WHERE : W H E R E ;
 

--- a/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
@@ -504,6 +504,7 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
 
     SqlDialect dialect = schemaManager.getDialect();
     if (importSynopsis
+        || mTable.getTableType().equals("JOIN")
         || (dialect instanceof TrainDBSqlDialect
             && !((TrainDBSqlDialect) dialect).supportCreateTableAsSelect())) {
       sb.append("(");
@@ -829,6 +830,7 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
         catalogContext.createExternalTable(synopsisName, "csv", synPath.toString());
         conn.refreshRootSchema();
         T_tracer.closeTaskTime("SUCCESS");
+        T_tracer.endTaskTracer();
         return;
       }
 
@@ -840,6 +842,7 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
       loadSynopsisIntoTable(synopsisName, mModel.getSchemaName(), mModel.getColumnNames(),
           mModel.getTable(), outputPath);
       T_tracer.closeTaskTime("SUCCESS");
+      T_tracer.endTaskTracer();
     } catch (Exception e) {
       try {
         dropSynopsisTable(synopsisName);
@@ -854,8 +857,6 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
 
       throw new TrainDBException(msg);
     }
-    T_tracer.closeTaskTime("SUCCESS");
-    T_tracer.endTaskTracer();
   }
 
   private void dropSynopsisTable(String synopsisName) throws Exception {

--- a/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
@@ -612,7 +612,7 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
       sb.append(schemaNames.get(i)).append(".").append(tableNames.get(i)).append(",");
     }
     sb.deleteCharAt(sb.lastIndexOf(","));
-    if (whereCondition != null) {
+    if (whereCondition != null && !whereCondition.isEmpty()) {
       sb.append(" WHERE ").append(whereCondition);
     }
     String sql = sb.toString();

--- a/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
@@ -377,11 +377,18 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
       sb.append(",");
     }
     sb.deleteCharAt(sb.lastIndexOf(","));
-    if (joinCondition != null) {
-      sb.append(" WHERE ").append(joinCondition);
-    }
+    String sampleClause = "";
     if (samplePercent > 0 && samplePercent < 100) {
-      sb.append(getTableSampleClause(samplePercent));
+      sampleClause = getTableSampleClause(samplePercent);
+      sb.append(sampleClause);
+    }
+    if (joinCondition != null) {
+      if (sampleClause.startsWith(" WHERE")) {
+        sb.append(" AND ");
+      } else {
+        sb.append(" WHERE ");
+      }
+      sb.append(joinCondition);
     }
 
     return sb.toString();

--- a/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
+++ b/traindb-core/src/main/java/traindb/engine/TrainDBQueryEngine.java
@@ -45,7 +45,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.sql.SqlDialect;
@@ -167,11 +170,8 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
     T_tracer.endTaskTracer();
   }
 
-  public JSONObject buildTableMetadata(
-      String schemaName, String tableName, List<String> columnNames,
-      Map<String, Object> trainOptions, RelDataType relDataType) {
-    JSONObject root = new JSONObject();
-    JSONObject fields = new JSONObject();
+  private void addTableMetadataFields(JSONObject fields, String schemaName, String tableName,
+                                      List<String> columnNames, RelDataType relDataType) {
     for (int i = 0; i < columnNames.size(); i++) {
       RelDataTypeField field = relDataType.getField(columnNames.get(i), true, false);
       JSONObject typeInfo = new JSONObject();
@@ -243,6 +243,37 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
 
       fields.put(columnNames.get(i), typeInfo);
     }
+  }
+
+  public JSONObject buildJoinTableMetadata(
+      String joinTableName, List<String> schemaNames, List<String> tableNames,
+      List<List<String>> columnNames, Map<String, Object> trainOptions,
+      List<RelDataType> relDataTypes) {
+    JSONObject root = new JSONObject();
+    JSONObject fields = new JSONObject();
+    for (int i = 0; i < tableNames.size(); i++) {
+      addTableMetadataFields(fields, schemaNames.get(i), tableNames.get(i), columnNames.get(i),
+          relDataTypes.get(i));
+    }
+    root.put("fields", fields);
+    root.put("schema", schemaNames.get(0));  // set first schema as join table's schema
+    root.put("table", joinTableName);
+
+    if (trainOptions != null) {
+      JSONObject options = new JSONObject();
+      options.putAll(trainOptions);
+      root.put("options", options);
+    }
+
+    return root;
+  }
+
+  public JSONObject buildTableMetadata(
+      String schemaName, String tableName, List<String> columnNames,
+      Map<String, Object> trainOptions, RelDataType relDataType) {
+    JSONObject root = new JSONObject();
+    JSONObject fields = new JSONObject();
+    addTableMetadataFields(fields, schemaName, tableName, columnNames, relDataType);
     root.put("fields", fields);
     root.put("schema", schemaName);
     root.put("table", tableName);
@@ -303,11 +334,51 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
     return sb.toString();
   }
 
+  private String buildJoinQuery(List<String> schemaNames, List<String> tableNames,
+                                List<List<String>> columnNames, float samplePercent,
+                                List<RelDataType> relDataTypes, String joinCondition)
+      throws TrainDBException {
+    StringBuilder sb = new StringBuilder();
+    sb.append("SELECT ");
+    for (int i = 0; i < columnNames.size(); i++) {
+      String tableName = tableNames.get(i);
+      List<String> colnames = columnNames.get(i);
+      RelDataType relDataType = relDataTypes.get(i);
+      for (int j = 0; j < colnames.size(); j++) {
+        RelDataTypeField field = relDataType.getField(colnames.get(j), true, false);
+        if (field.getType().getSqlTypeName() == SqlTypeName.GEOMETRY) {
+          sb.append("ST_ASTEXT(").append(tableName).append(".").append(colnames.get(j))
+              .append(") AS ").append(colnames.get(j));
+        } else {
+          sb.append(tableName).append(".").append(colnames.get(j));
+        }
+        sb.append(",");
+      }
+    }
+    sb.deleteCharAt(sb.lastIndexOf(","));
+    sb.append(" FROM ");
+    for (int i = 0; i < tableNames.size(); i++) {
+      sb.append(schemaNames.get(i));
+      sb.append(".");
+      sb.append(tableNames.get(i));
+      sb.append(",");
+    }
+    sb.deleteCharAt(sb.lastIndexOf(","));
+    if (joinCondition != null) {
+      sb.append(" WHERE ").append(joinCondition);
+    }
+    if (samplePercent > 0 && samplePercent < 100) {
+      sb.append(getTableSampleClause(samplePercent));
+    }
+
+    return sb.toString();
+  }
+
   @Override
   public void trainModel(
-      String modeltypeName, String modelName, String schemaName, String tableName,
-      List<String> columnNames, float samplePercent, Map<String, Object> trainOptions)
-      throws Exception {
+      String modeltypeName, String modelName, List<String> schemaNames, List<String> tableNames,
+      List<List<String>> columnNames, String joinCondition, float samplePercent,
+      Map<String, Object> trainOptions) throws Exception {
     T_tracer.startTaskTracer("train model " + modelName);
 
     T_tracer.openTaskTime("find : modeltype");
@@ -332,36 +403,72 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
     }
     T_tracer.closeTaskTime("SUCCESS");
 
-    if (schemaName == null) {
-      schemaName = conn.getSchema();
+    List<RelDataType> rowTypes = new ArrayList<>();
+    for (int i = 0; i < tableNames.size(); i++) {
+      if (schemaNames.get(i) == null) {
+        schemaNames.set(i, conn.getSchema());
+      }
+      TrainDBTable table = schemaManager.getTable(schemaNames.get(i), tableNames.get(i));
+      if (table == null) {
+        throw new TrainDBException("cannot find the table '" + schemaNames.get(i) + "'.'"
+            + tableNames.get(i) + "'");
+      }
+      rowTypes.add(table.getRowType(conn.getTypeFactory()));
     }
 
-    TrainDBTable table = schemaManager.getTable(schemaName, tableName);
-    if (table == null) {
-      throw new TrainDBException("cannot find the table '" + schemaName + "'.'" + tableName + "'");
+    String tableName;
+    JSONObject tableMetadata;
+    String sql;
+    RelDataType rowType;
+    MTable joinTable = null;
+    if (tableNames.size() > 1) {  // JOIN TABLE
+      sql = buildJoinQuery(
+          schemaNames, tableNames, columnNames, samplePercent, rowTypes, joinCondition);
+      joinTable =
+          catalogContext.createJoinTable(schemaNames, tableNames, columnNames, rowTypes, sql);
+      tableName = joinTable.getTableName();
+      tableMetadata = buildJoinTableMetadata(
+          joinTable.getTableName(), schemaNames, tableNames, columnNames, trainOptions, rowTypes);
+      rowType = null;
+    } else {  // tableNames.size() == 1
+      tableName = tableNames.get(0);
+      tableMetadata = buildTableMetadata(
+          schemaNames.get(0), tableName, columnNames.get(0), trainOptions, rowTypes.get(0));
+      sql = buildSelectTrainingDataQuery(
+          schemaNames.get(0), tableName, columnNames.get(0), samplePercent, rowTypes.get(0));
+      rowType = rowTypes.get(0);
     }
-    Long baseTableRows = getTableRowCount(schemaName, tableName);
+    Long baseTableRows = getTableRowCount(schemaNames, tableNames, joinCondition);
     Long trainedRows = (long) (baseTableRows * (samplePercent / 100.0)); // FIXME: not exact
 
-    RelDataType rowType = table.getRowType(conn.getTypeFactory());
-    JSONObject tableMetadata = buildTableMetadata(
-        schemaName, tableName, columnNames, trainOptions, rowType);
-    String sql = buildSelectTrainingDataQuery(
-        schemaName, tableName, columnNames, samplePercent, rowType);
+    try {
+      T_tracer.openTaskTime("train model");
+      AbstractTrainDBModelRunner runner = createModelRunner(
+          modeltypeName, modelName, catalogContext.getModeltype(modeltypeName).getLocation());
+      runner.trainModel(tableMetadata, sql);
+      T_tracer.closeTaskTime("SUCCESS");
 
-    T_tracer.openTaskTime("train model");
-    AbstractTrainDBModelRunner runner = createModelRunner(
-        modeltypeName, modelName, catalogContext.getModeltype(modeltypeName).getLocation());
-    runner.trainModel(tableMetadata, sql);
-    T_tracer.closeTaskTime("SUCCESS");
+      T_tracer.openTaskTime("insert model info");
+      JSONObject options = (JSONObject) tableMetadata.get("options");
+      List<String> flatColumnNames =
+          columnNames.stream().flatMap(List::stream).collect(Collectors.toList());
+      catalogContext.trainModel(modeltypeName, modelName, schemaNames.get(0), tableName,
+          flatColumnNames, rowType, baseTableRows, trainedRows, options.toString());
+      T_tracer.closeTaskTime("SUCCESS");
 
-    T_tracer.openTaskTime("insert model info");
-    JSONObject options = (JSONObject) tableMetadata.get("options");
-    catalogContext.trainModel(modeltypeName, modelName, schemaName, tableName, columnNames,
-        rowType, baseTableRows, trainedRows, options.toString());
-    T_tracer.closeTaskTime("SUCCESS");
+      T_tracer.endTaskTracer();
+    } catch (Exception e) {
+      if (joinTable != null) {
+        catalogContext.dropJoinTable(
+            joinTable.getSchema().getSchemaName(), joinTable.getTableName());
+      }
 
-    T_tracer.endTaskTracer();
+      String msg = "failed to train model " + modelName;
+      T_tracer.closeTaskTime(msg);
+      T_tracer.endTaskTracer();
+
+      throw new TrainDBException(msg);
+    }
   }
 
   @Override
@@ -496,9 +603,18 @@ public class TrainDBQueryEngine implements TrainDBSqlRunner {
     }
   }
 
-
-  private long getTableRowCount(String schemaName, String tableName) throws SQLException {
-    String sql = "SELECT count(*) FROM " + schemaName + "." + tableName;
+  private long getTableRowCount(List<String> schemaNames, List<String> tableNames,
+                                String whereCondition) throws SQLException {
+    StringBuilder sb = new StringBuilder();
+    sb.append("SELECT count(*) FROM ");
+    for (int i = 0; i < tableNames.size(); i++) {
+      sb.append(schemaNames.get(i)).append(".").append(tableNames.get(i)).append(",");
+    }
+    sb.deleteCharAt(sb.lastIndexOf(","));
+    if (whereCondition != null) {
+      sb.append(" WHERE ").append(whereCondition);
+    }
+    String sql = sb.toString();
 
     Connection extConn = conn.getDataSourceConnection();
     Statement stmt = extConn.createStatement();

--- a/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisAggregateScanRule.java
+++ b/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisAggregateScanRule.java
@@ -89,8 +89,8 @@ public class ApproxAggregateSynopsisAggregateScanRule
         (RelOptTableImpl) planner.getSynopsisTable(bestSynopsis, scan.getTable());
     TableScan newScan = planner.createSynopsisTableScan(bestSynopsis, synopsisTable, scan);
 
-    List<RexNode> aggProjects = ApproxAggregateUtil.makeAggregateProjects(
-        aggregate, scan.getTable(), synopsisTable.getRowCount());
+    double scaleFactor = scan.getTable().getRowCount() / synopsisTable.getRowCount();
+    List<RexNode> aggProjects = ApproxAggregateUtil.makeAggregateProjects(aggregate, scaleFactor);
     List<RexNode> newGroupSet = ApproxAggregateUtil.makeAggregateGroupSet(aggregate, mapping);
 
     final ImmutableList.Builder<AggregateCall> newAggCalls = ImmutableList.builder();

--- a/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisFilterScanRule.java
+++ b/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisFilterScanRule.java
@@ -114,8 +114,8 @@ public class ApproxAggregateSynopsisFilterScanRule
           (RelOptTableImpl) planner.getSynopsisTable(bestSynopsis, scan.getTable());
       TableScan newScan = planner.createSynopsisTableScan(bestSynopsis, synopsisTable, scan);
 
-      List<RexNode> aggProjects = ApproxAggregateUtil.makeAggregateProjects(
-          aggregate, scan.getTable(), synopsisTable.getRowCount());
+      double scaleFactor = scan.getTable().getRowCount() / synopsisTable.getRowCount();
+      List<RexNode> aggProjects = ApproxAggregateUtil.makeAggregateProjects(aggregate, scaleFactor);
       List<RexNode> newGroupSet = ApproxAggregateUtil.makeAggregateGroupSet(aggregate, mapping);
 
       final ImmutableList.Builder<AggregateCall> newAggCalls = ImmutableList.builder();

--- a/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisProjectScanRule.java
+++ b/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisProjectScanRule.java
@@ -104,8 +104,8 @@ public class ApproxAggregateSynopsisProjectScanRule
           (RelOptTableImpl) planner.getSynopsisTable(bestSynopsis, scan.getTable());
       TableScan newScan = planner.createSynopsisTableScan(bestSynopsis, synopsisTable, scan);
 
-      List<RexNode> aggProjects = ApproxAggregateUtil.makeAggregateProjects(
-          aggregate, scan.getTable(), synopsisTable.getRowCount());
+      double scaleFactor = scan.getTable().getRowCount() / synopsisTable.getRowCount();
+      List<RexNode> aggProjects = ApproxAggregateUtil.makeAggregateProjects(aggregate, scaleFactor);
 
       RelNode node = relBuilder.push(newScan)
           .project(newProjects, project.getRowType().getFieldNames())

--- a/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisRule.java
+++ b/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisRule.java
@@ -278,8 +278,8 @@ public class ApproxAggregateSynopsisRule
         relBuilder.aggregate(relBuilder.groupKey(newGroupSet), newAggCalls.build());
       }
 
-      List<RexNode> aggProjects = ApproxAggregateUtil.makeAggregateProjects(
-          aggregate, scan.getTable(), synopsisTable.getRowCount());
+      double scaleFactor = scan.getTable().getRowCount() / synopsisTable.getRowCount();
+      List<RexNode> aggProjects = ApproxAggregateUtil.makeAggregateProjects(aggregate, scaleFactor);
       relBuilder.project(aggProjects, aggregate.getRowType().getFieldNames());
 
       call.transformTo(relBuilder.build());

--- a/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisRule.java
+++ b/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateSynopsisRule.java
@@ -17,8 +17,10 @@ package traindb.planner.rules;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelRule;
@@ -37,6 +39,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.util.mapping.Mappings;
 import org.immutables.value.Value;
@@ -133,6 +136,40 @@ public class ApproxAggregateSynopsisRule
     return requiredColumnIndex;
   }
 
+  private String getConditionString(RelNode node, List<TableScan> scans) {
+    String condStr = "";
+    if (node instanceof Join) {
+      Join join = (Join) node;
+      RexNode joinCondition = join.getCondition();
+      if (joinCondition instanceof RexCall) {
+        List<RexNode> operands = ((RexCall) joinCondition).getOperands();
+        List<Integer> inputRefIndex = getRexInputRefIndex(operands);
+        SqlOperator operator = ((RexCall) joinCondition).getOperator();
+        int li;
+        int ri;
+        if (inputRefIndex.get(0) < inputRefIndex.get(1)) {
+          li = inputRefIndex.get(0);
+          ri = inputRefIndex.get(1) - join.getLeft().getRowType().getFieldCount();
+        } else {
+          li = inputRefIndex.get(1);
+          ri = inputRefIndex.get(0) - join.getLeft().getRowType().getFieldCount();
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(scans.get(0).getTable().getQualifiedName().get(2));
+        sb.append(".");
+        sb.append(join.getLeft().getRowType().getFieldNames().get(li));
+        sb.append(" ").append(operator).append(" ");
+        sb.append(scans.get(1).getTable().getQualifiedName().get(2));
+        sb.append(".");
+        sb.append(join.getRight().getRowType().getFieldNames().get(ri));
+        condStr = sb.toString();
+      }
+    }
+
+    return condStr;
+  }
+
   private Mappings.TargetMapping createMapping(List<String> fromColumns, List<String> toColumns) {
     List<Integer> targets = new ArrayList<>();
     for (int i = 0; i < fromColumns.size(); i++) {
@@ -152,24 +189,52 @@ public class ApproxAggregateSynopsisRule
 
     final Aggregate aggregate = call.rel(0);
     List<TableScan> tableScans = ApproxAggregateUtil.findAllTableScans(aggregate);
+    Map<Join, List<TableScan>> joinScanMap = new HashMap<>();
+    Map<Join, List<Filter>> joinFilterMap = new HashMap<>();
+    Map<TableScan, List<String>> requiredScanColumnMap = new HashMap<>();
     for (TableScan scan : tableScans) {
       if (!isApplicable(aggregate, scan)) {
         continue;
       }
 
+      // build required column information for each table scan
       Set<Integer> requiredColumnIndex = new HashSet<>();
+      List<Filter> filterList = new ArrayList<>();
       int start = 0;
       int end = scan.getRowType().getFieldCount();
-      RelNode node, parent;
+      boolean projected = false;
+      RelNode node;
+      RelNode parent;
       for (node = scan, parent = ApproxAggregateUtil.getParent(aggregate, scan);
            node != aggregate;
            node = parent, parent = ApproxAggregateUtil.getParent(aggregate, node)) {
         if (parent instanceof Join) {
-          RelNode left = ((Join) parent).getLeft();
+          Join parentJoin = (Join) parent;
+          List<TableScan> joinScans = joinScanMap.get(parentJoin);
+          if (joinScans == null) {
+            joinScans = new ArrayList<>();
+            joinScans.add(scan);
+            joinScanMap.put(parentJoin, joinScans);
+          } else {
+            joinScans.add(scan);
+          }
+          if (!filterList.isEmpty()) {
+            List<Filter> joinFilters = joinFilterMap.get(parentJoin);
+            if (joinFilters == null) {
+              joinFilterMap.put(parentJoin, filterList);
+            } else {
+              joinFilters.addAll(filterList);
+            }
+          }
+          if (projected) {
+            continue;
+          }
+
+          RelNode left = parentJoin.getLeft();
           if (left instanceof RelSubset) {
             left = ((RelSubset) left).getBestOrOriginal();
           }
-          RelNode right = ((Join) parent).getRight();
+          RelNode right = parentJoin.getRight();
           if (right instanceof RelSubset) {
             right = ((RelSubset) right).getBestOrOriginal();
           }
@@ -177,15 +242,123 @@ public class ApproxAggregateSynopsisRule
             start = left.getRowType().getFieldCount();
             end = left.getRowType().getFieldCount() + right.getRowType().getFieldCount();
           }
+        } else if (parent instanceof Filter) {
+          filterList.add((Filter) parent);
         }
+
+        if (projected) {
+          continue;
+        }
+
         requiredColumnIndex.addAll(getRequiredColumnIndex(parent, start, end));
         if (parent instanceof Project) {
-          break;
+          projected = true;
         }
       }
+
       List<String> inputColumns = scan.getRowType().getFieldNames();
       List<String> requiredColumnNames =
           ApproxAggregateUtil.getSublistByIndex(inputColumns, new ArrayList(requiredColumnIndex));
+      requiredScanColumnMap.put(scan, requiredColumnNames);
+    }
+
+    // try join synopses first
+    for (Map.Entry<Join, List<TableScan>> entry : joinScanMap.entrySet()) {
+      Join join = entry.getKey();
+      List<TableScan> joinScans = entry.getValue();
+      String condStr = getConditionString(join, joinScans);
+      Collection<MSynopsis> candidateJoinSynopses =
+          planner.getAvailableJoinSynopses(joinScans, requiredScanColumnMap, condStr);
+      if (candidateJoinSynopses == null || candidateJoinSynopses.isEmpty()) {
+        continue;
+      }
+      List<String> requiredJoinColumnNames = new ArrayList<>();
+      for (TableScan joinScan : joinScans) {
+        requiredJoinColumnNames.addAll(requiredScanColumnMap.get(joinScan));
+      }
+
+      TableScan baseScan = joinScans.get(0);
+      MSynopsis bestSynopsis = planner.getBestSynopsis(
+          candidateJoinSynopses, baseScan, aggregate.getHints(), requiredJoinColumnNames);
+
+      RelOptTableImpl synopsisTable =
+          (RelOptTableImpl) planner.getSynopsisTable(bestSynopsis, baseScan.getTable());
+      if (synopsisTable == null) {
+        return;
+      }
+      TableScan newScan = planner.createSynopsisTableScan(bestSynopsis, synopsisTable, baseScan);
+      relBuilder.push(newScan);
+
+      List<String> synopsisColumns = bestSynopsis.getColumnNames();
+      List<String> inputColumns = new ArrayList<>();
+      inputColumns.addAll(join.getLeft().getRowType().getFieldNames());
+      inputColumns.addAll(join.getRight().getRowType().getFieldNames());
+      final Mappings.TargetMapping mapping = createMapping(inputColumns, synopsisColumns);
+      List<Filter> joinFilters = joinFilterMap.get(join);
+      if (joinFilters != null) {
+        for (Filter f : joinFilters) {
+          relBuilder.filter(f.getCondition());
+        }
+      }
+      relBuilder.project(relBuilder.fields(mapping), join.getRowType().getFieldNames(), true);
+
+      RelNode child;
+      RelNode node;
+      for (child = join, node = ApproxAggregateUtil.getParent(aggregate, join);
+           node != aggregate; child = node, node = ApproxAggregateUtil.getParent(aggregate, node)) {
+        if (node instanceof Filter) {
+          Filter filter = (Filter) node;
+          relBuilder.filter(filter.getCondition());
+        } else if (node instanceof Join) {
+          Join oj = (Join) node;
+          RexNode newCondition;
+          newCondition = oj.getCondition();
+          RelNode left = oj.getLeft();
+          RelNode right = oj.getRight();
+          if (left instanceof RelSubset
+              && ((RelSubset) left).getBestOrOriginal() == child) {
+            final Join newJoin =
+                oj.copy(oj.getTraitSet(), newCondition, relBuilder.peek(), oj.getRight(),
+                    oj.getJoinType(), oj.isSemiJoinDone());
+            relBuilder.clear();
+            relBuilder.push(newJoin);
+          } else if (right instanceof RelSubset
+              && ((RelSubset) right).getBestOrOriginal() == child) {
+            final Join newJoin =
+                oj.copy(oj.getTraitSet(), newCondition, oj.getLeft(), relBuilder.peek(),
+                    oj.getJoinType(), oj.isSemiJoinDone());
+            relBuilder.clear();
+            relBuilder.push(newJoin);
+          } else {
+            return;
+          }
+        } else if (node instanceof Project) {
+          Project project = (Project) node;
+          relBuilder.project(project.getProjects(), project.getRowType().getFieldNames());
+        } else {
+          break; /* cannot apply this rule */
+        }
+      }
+
+      if (node != aggregate) {
+        continue;
+      }
+      relBuilder.aggregate(relBuilder.groupKey(aggregate.getGroupSet()),
+          aggregate.getAggCallList());
+
+      double scaleFactor = 1.0 / bestSynopsis.getRatio();
+      List<RexNode> aggProjects = ApproxAggregateUtil.makeAggregateProjects(aggregate, scaleFactor);
+      relBuilder.project(aggProjects, aggregate.getRowType().getFieldNames());
+
+      call.transformTo(relBuilder.build());
+      return;
+    }
+
+    // apply synopses on single tables
+    for (Map.Entry<TableScan, List<String>> entry : requiredScanColumnMap.entrySet()) {
+      TableScan scan = entry.getKey();
+      List<String> requiredColumnNames = entry.getValue();
+      List<String> inputColumns = scan.getRowType().getFieldNames();
 
       List<String> qualifiedTableName = scan.getTable().getQualifiedName();
       Collection<MSynopsis> candidateSynopses =
@@ -212,6 +385,7 @@ public class ApproxAggregateSynopsisRule
 
       boolean projected = false;
       RelNode child;
+      RelNode node;
       for (child = scan, node = ApproxAggregateUtil.getParent(aggregate, scan);
            node != aggregate; child = node, node = ApproxAggregateUtil.getParent(aggregate, node)) {
         if (node instanceof Filter) {

--- a/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateUtil.java
+++ b/traindb-core/src/main/java/traindb/planner/rules/ApproxAggregateUtil.java
@@ -152,9 +152,7 @@ public class ApproxAggregateUtil {
     return newGroupSet;
   }
 
-  public static List<RexNode> makeAggregateProjects(Aggregate aggregate,
-                                                    RelOptTable baseTable,
-                                                    double synopsisRowCount) {
+  public static List<RexNode> makeAggregateProjects(Aggregate aggregate, double scaleFactor) {
     final RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
     List<RexNode> aggProjects = new ArrayList<>();
     for (int key : aggregate.getGroupSet()) {
@@ -163,7 +161,6 @@ public class ApproxAggregateUtil {
       aggProjects.add(rexBuilder.makeInputRef(rowTypeForKey, aggProjects.size()));
     }
 
-    double scaleFactor = baseTable.getRowCount() / synopsisRowCount;
     for (AggregateCall aggCall : aggregate.getAggCallList()) {
       RexNode expr;
       String aggFuncName = aggCall.getAggregation().getName();

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
@@ -312,7 +312,9 @@ public final class TrainDBSql {
 
       String joinCondition = "";
       if (ctx.joinTableConditionListOpt() != null) {
-        joinCondition = ctx.joinTableConditionListOpt().tableConditionList().getText();
+        int start = ctx.joinTableConditionListOpt().tableConditionList().start.getStartIndex();
+        int stop = ctx.joinTableConditionListOpt().tableConditionList().stop.getStopIndex();
+        joinCondition = ctx.start.getInputStream().getText(new Interval(start, stop));
       }
 
       float samplePercent = 100;

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
@@ -79,8 +79,8 @@ public final class TrainDBSql {
         TrainDBSqlTrainModel trainModel = (TrainDBSqlTrainModel) command;
         runner.trainModel(
             trainModel.getModeltypeName(), trainModel.getModelName(),
-            trainModel.getSchemaNames().get(0), trainModel.getTableNames().get(0),
-            trainModel.getColumnNames().get(0), trainModel.getSamplePercent(),
+            trainModel.getSchemaNames(), trainModel.getTableNames(), trainModel.getColumnNames(),
+            trainModel.getJoinCondition(), trainModel.getSamplePercent(),
             trainModel.getTrainOptions());
         break;
       case DROP_MODEL:

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSql.java
@@ -79,8 +79,8 @@ public final class TrainDBSql {
         TrainDBSqlTrainModel trainModel = (TrainDBSqlTrainModel) command;
         runner.trainModel(
             trainModel.getModeltypeName(), trainModel.getModelName(),
-            trainModel.getSchemaName(), trainModel.getTableName(),
-            trainModel.getColumnNames(), trainModel.getSamplePercent(),
+            trainModel.getSchemaNames().get(0), trainModel.getTableNames().get(0),
+            trainModel.getColumnNames().get(0), trainModel.getSamplePercent(),
             trainModel.getTrainOptions());
         break;
       case DROP_MODEL:
@@ -286,9 +286,33 @@ public final class TrainDBSql {
       String modelName = ctx.modelName().getText();
       String modeltypeName = ctx.modeltypeName().getText();
 
-      List<String> columnNames = new ArrayList<>();
+      List<String> schemaNames = new ArrayList<>();
+      List<String> tableNames = new ArrayList<>();
+      List<List<String>> columnNames = new ArrayList<>();
+
+      schemaNames.add(ctx.tableName().schemaName().getText());
+      tableNames.add(ctx.tableName().tableIdentifier.getText());
+      List<String> tableColumnNames = new ArrayList<>();
       for (TrainDBSqlParser.ColumnNameContext columnName : ctx.columnNameList().columnName()) {
-        columnNames.add(columnName.getText());
+        tableColumnNames.add(columnName.getText());
+      }
+      columnNames.add(tableColumnNames);
+
+      if (ctx.joinTableListOpt() != null) {
+        for (TrainDBSqlParser.JoinTableListOptContext jtl : ctx.joinTableListOpt()) {
+          schemaNames.add(jtl.tableName().schemaName().getText());
+          tableNames.add(jtl.tableName().tableIdentifier.getText());
+          List<String> joinTableColumnNames = new ArrayList<>();
+          for (TrainDBSqlParser.ColumnNameContext columnName : jtl.columnNameList().columnName()) {
+            joinTableColumnNames.add(columnName.getText());
+          }
+          columnNames.add(joinTableColumnNames);
+        }
+      }
+
+      String joinCondition = "";
+      if (ctx.joinTableConditionListOpt() != null) {
+        joinCondition = ctx.joinTableConditionListOpt().tableConditionList().getText();
       }
 
       float samplePercent = 100;
@@ -306,11 +330,9 @@ public final class TrainDBSql {
       }
       LOG.debug("TRAIN MODEL: name=" + modelName + " type=" + modeltypeName);
 
-      String schemaName = ctx.tableName().schemaName().getText();
-      String tableName = ctx.tableName().tableIdentifier.getText();
       commands.add(new TrainDBSqlTrainModel(
-          modeltypeName, modelName, schemaName, tableName, columnNames, samplePercent,
-          trainOptions));
+          modeltypeName, modelName, schemaNames, tableNames, columnNames, joinCondition,
+          samplePercent, trainOptions));
     }
 
     @Override

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSqlRunner.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSqlRunner.java
@@ -25,8 +25,9 @@ public interface TrainDBSqlRunner {
 
   void dropModeltype(String name) throws Exception;
 
-  void trainModel(String modeltypeName, String modelName, String schemaName, String tableName,
-                  List<String> columnNames, float samplePercent, Map<String, Object> trainOptions)
+  void trainModel(String modeltypeName, String modelName, List<String> schemaNames,
+                  List<String> tableNames, List<List<String>> columnNames, String joinCondition,
+                  float samplePercent, Map<String, Object> trainOptions)
       throws Exception;
 
   void dropModel(String modelName) throws Exception;

--- a/traindb-core/src/main/java/traindb/sql/TrainDBSqlTrainModel.java
+++ b/traindb-core/src/main/java/traindb/sql/TrainDBSqlTrainModel.java
@@ -20,20 +20,23 @@ import java.util.Map;
 class TrainDBSqlTrainModel extends TrainDBSqlCommand {
   private final String modeltypeName;
   private final String modelName;
-  private final String schemaName;
-  private final String tableName;
-  private final List<String> columnNames;
+  private final List<String> schemaNames;
+  private final List<String> tableNames;
+  private final List<List<String>> columnNames;
+  private final String joinCondition;
   private final float samplePercent;
   private final Map<String, Object> trainOptions;
 
-  TrainDBSqlTrainModel(String modeltypeName, String modelName, String schemaName, String tableName,
-                       List<String> columnNames, float samplePercent,
+  TrainDBSqlTrainModel(String modeltypeName, String modelName, List<String> schemaNames,
+                       List<String> tableNames, List<List<String>> columnNames,
+                       String joinCondition, float samplePercent,
                        Map<String, Object> trainOptions) {
     this.modeltypeName = modeltypeName;
     this.modelName = modelName;
-    this.schemaName = schemaName;
-    this.tableName = tableName;
+    this.schemaNames = schemaNames;
+    this.tableNames = tableNames;
     this.columnNames = columnNames;
+    this.joinCondition = joinCondition;
     this.samplePercent = samplePercent;
     this.trainOptions = trainOptions;
   }
@@ -46,16 +49,20 @@ class TrainDBSqlTrainModel extends TrainDBSqlCommand {
     return modelName;
   }
 
-  String getSchemaName() {
-    return schemaName;
+  List<String> getSchemaNames() {
+    return schemaNames;
   }
 
-  String getTableName() {
-    return tableName;
+  List<String> getTableNames() {
+    return tableNames;
   }
 
-  List<String> getColumnNames() {
+  List<List<String>> getColumnNames() {
     return columnNames;
+  }
+
+  String getJoinCondition() {
+    return joinCondition;
   }
 
   float getSamplePercent() {


### PR DESCRIPTION
A new feature has been implemented to train models and generate synopses for columns in multiple tables.

For example, it is possible to train a model by joining the two tables ```orders``` and ```order_products``` in the instacart benchmark by order_id as follows:

```console
trsql> TRAIN MODEL ctgan_join MODELTYPE ctgan 
       FROM instacart.orders(order_id, order_dow) 
       JOIN instacart.order_products(order_id, product_id, add_to_cart_order, reordered) 
       ON orders.order_id = order_products.order_id 
       OPTIONS ('epochs' = 100);
```

After training the model, the process of generating synopses and running approximate queries is the same as in simple queries.
```console
trsql> CREATE SYNOPSIS ctgan_join_syn FROM MODEL ctgan_join LIMIT 10 PERCENT;
```
```console
trsql> EXPLAIN PLAN for 
       SELECT APPROXIMATE product_name, count(*) as order_count 
       FROM instacart.order_products, instacart.orders, instacart.products
       WHERE orders.order_id = order_products.order_id
         AND order_products.product_id = products.product_id
         AND (order_dow = 0 OR order_dow = 1)
       GROUP BY product_name ORDER BY order_count DESC LIMIT 5;
+------------------------------------------------------------------------------------------------------------------+
|                                                       PLAN                                                       |
+------------------------------------------------------------------------------------------------------------------+
| JdbcToEnumerableConverter
  JdbcSort(sort0=[$1], dir0=[DESC], fetch=[5])
    JdbcProject(product_name=[$0], order_count=[CAST(*(10.00000177414538:DECIMAL(16, 14), $1)):BIGINT NOT NULL])
      JdbcAggregate(group=[{5}], order_count=[COUNT()])
        JdbcJoin(condition=[=($1, $4)], joinType=[inner])
          JdbcProject(order_id=[$0], product_id=[$2], order_id0=[$0], order_dow=[$1])
            JdbcFilter(condition=[AND(=($0, $0), OR(=($1, 0), =($1, 1)))])
              JdbcTableScan(table=[[jdbc, instacart, ctgan_join_syn]])  <- synopsis scan replacing join
          JdbcProject(product_id=[$0], product_name=[$1])
            JdbcTableScan(table=[[jdbc, instacart, products]])
 |
+------------------------------------------------------------------------------------------------------------------+
```